### PR TITLE
:sparkles: disable timer for non editor

### DIFF
--- a/elements/README.md
+++ b/elements/README.md
@@ -28,11 +28,30 @@ Inside your javascript code, you will be able to access some information about t
 here a complete list of keys available on it:
 
 - `id`: the fresco element id. Will be uniq
-- `participantId`: a unique ID for each participant.
-- `isLocalParticipantInside`: a flag to know if the local participant position is inside the shape bounds.
-- `totalParticipantsCount`: the number of participant currenlty in the space
 - `state`: the state object, see next section
 - `storage`: the storage object, see next section
+
+also some depreacted key that have been moved:
+- `participantId`: Moved into `fresco.localParticipant.id`
+- `isLocalParticipantInside`: Moved into  `fresco.localParticipant.isInsideElement`
+- `totalParticipantsCount`:  Replaced by into  `fresco.remoteParticipants.length`
+
+
+## fresco.space
+ - `id`: the curren fresco space id, also knows as diagramId
+
+## fresco.localParticipant
+ - `id`: current id of the local participant. not persistant across sessions
+ - `permission`: an object with permission of local user inside the space
+    - `canAccess`: boolean; Whether the user is allowd to access the space. should always be true at this point;
+    - `canEdit`: boolean; Whether the user can make any modification to the space;
+    - `canLock`: boolean; Whether the user edit locked objects;
+    - `canConfig`: boolean; Whether the user can update the space settings;
+- `isInsideElement`: a flag to know if the local participant position is inside the shape bounds.
+
+## fresco.remoteParticipants
+ - `length` : the number of remote participants
+
 
 ## State, configuration and storage
 

--- a/elements/timer/index.htm
+++ b/elements/timer/index.htm
@@ -12,6 +12,9 @@
                 font-size: 6rem;
                 cursor: pointer;
             }
+            button:disabled {
+                cursor: not-allowed;
+            }
 
             .button--done {
                 background-color: red;

--- a/elements/timer/index.js
+++ b/elements/timer/index.js
@@ -78,7 +78,7 @@ fresco.onReady(function () {
             startTimer(targetTime, new Date().getTime());
         }
 
-        if (!fresco.element.permission.canEdit) {
+        if (!fresco.localParticipant.permission.canEdit) {
             button.setAttribute('disabled', true);
         } else {
             button.removeAttribute('disabled');
@@ -89,8 +89,8 @@ fresco.onReady(function () {
 
     fresco.initialize(defaultState, elementConfig);
     button.addEventListener('click', toggleTimer);
-    if (fresco.element.permission){
-        if (!fresco.element.permission.canEdit) {
+    if (fresco.localParticipant.permission) {
+        if (!fresco.localParticipant.permission.canEdit) {
             button.setAttribute('disabled', true);
         }
     }

--- a/elements/timer/index.js
+++ b/elements/timer/index.js
@@ -77,9 +77,23 @@ fresco.onReady(function () {
             targetTime = fresco.element.state.startedAt + fresco.element.state.duration * 60 * 1000;
             startTimer(targetTime, new Date().getTime());
         }
+
+        if (!fresco.element.permission.canEdit) {
+            button.setAttribute('disabled', true);
+        } else {
+            button.removeAttribute('disabled');
+        }
+
+
     });
+
     fresco.initialize(defaultState, elementConfig);
     button.addEventListener('click', toggleTimer);
+    if (fresco.element.permission){
+        if (!fresco.element.permission.canEdit) {
+            button.setAttribute('disabled', true);
+        }
+    }
 });
 
 


### PR DESCRIPTION
this PR allows only participants with edit permission to trigger the timer.

it can not be merged as it, since it requires a new addition to the SDK, (exposing permissions)

- [x] Needs https://github.com/fres-co/fresco/pull/1075