### PR TITLE
:sparkles: give the possibility to teleport to a new zone after each vote

### DIFF
--- a/elements/reigns/src/App.tsx
+++ b/elements/reigns/src/App.tsx
@@ -47,7 +47,19 @@ const useFresco = function () {
       stats: state.game.stats,
     });
   };
-  return updateFrescoState;
+
+  const teleport = (target: string, targetPrefix = `${fresco.element.appearance.NAME}-`) => fresco.send({
+    type: "extension/out/redux",
+    payload: {
+      senderId: fresco.element.id,
+      action: {
+        userId: undefined,
+        type: "TELEPORT",
+        payload: { anchorName: `${targetPrefix}${target}` },
+    },
+  }})
+
+  return { updateFrescoState, teleport };
 };
 
 export default function App() {
@@ -65,15 +77,17 @@ export default function App() {
     }
     dispatch(initializeGame(gameUrl) as any);
   }, [gameUrl]);
-  const updateFrescoState = useFresco();
+  const { updateFrescoState, teleport }= useFresco();
 
   const doAnswerNo = () => {
     dispatch(answerNo());
     updateFrescoState();
+    teleport('neutral')
   };
   const doAnswerYes = () => {
     dispatch(answerYes());
     updateFrescoState();
+    teleport('neutral')
   };
   const doStartGame = () => {
     dispatch(startGame());

--- a/elements/reigns/src/App.tsx
+++ b/elements/reigns/src/App.tsx
@@ -51,9 +51,7 @@ const useFresco = function () {
   const teleport = (target: string, targetPrefix = `${fresco.element.appearance.NAME}-`) => fresco.send({
     type: "extension/out/redux",
     payload: {
-      senderId: fresco.element.id,
       action: {
-        userId: undefined,
         type: "TELEPORT",
         payload: { anchorName: `${targetPrefix}${target}` },
     },

--- a/elements/reigns/src/fresco.d.ts
+++ b/elements/reigns/src/fresco.d.ts
@@ -9,15 +9,23 @@ interface IInitializeOptions {
     toolbarButtons: IToolbarButton[];
 }
 
+type AppearanceValue = string | number | boolean | Record<string, AppearanceValue>
+
 interface IFrescoSdk {
     onReady(callback: () => void): void;
     onStateChanged(callback: () => void): void;
     element: {
         state: any; 
+        id: string;
+        name: string;
+        appearance: Record<string, AppearanceValue>
     };
     setState(state: any): void;
     initialize(defaultState: any, options: IInitializeOptions): void;
+    send(action: {
+        type: string,
+        payload: any
+    }) : void
 }
-
 
 declare var fresco: IFrescoSdk;


### PR DESCRIPTION
Inside the `Reigns` like game, after each vote, we want to give the possibility to reset the user position to a neutral zone.
this PR implements this.
it use the extension name to prefix the new destination zone name, which should be like `<name>-neutral`