### PR TITLE
Reigns/vote with global event

### DIFF
--- a/elements/reigns/src/App.tsx
+++ b/elements/reigns/src/App.tsx
@@ -47,7 +47,19 @@ const useFresco = function () {
       stats: state.game.stats,
     });
   };
-  return updateFrescoState;
+
+  const teleport = (target: string, targetPrefix = `${fresco.element.appearance.NAME}-`) => fresco.send({
+    type: "extension/out/redux",
+    payload: {
+      senderId: fresco.element.id,
+      action: {
+        userId: undefined,
+        type: "TELEPORT",
+        payload: { anchorName: `${targetPrefix}${target}` },
+    },
+  }})
+
+  return { updateFrescoState, teleport };
 };
 
 export default function App() {
@@ -65,15 +77,17 @@ export default function App() {
     }
     dispatch(initializeGame(gameUrl) as any);
   }, [gameUrl]);
-  const updateFrescoState = useFresco();
+  const { updateFrescoState, teleport }= useFresco();
 
   const doAnswerNo = () => {
     dispatch(answerNo());
     updateFrescoState();
+    teleport('neutral')
   };
   const doAnswerYes = () => {
     dispatch(answerYes());
     updateFrescoState();
+    teleport('neutral')
   };
   const doStartGame = () => {
     dispatch(startGame());

--- a/elements/reigns/src/App.tsx
+++ b/elements/reigns/src/App.tsx
@@ -84,11 +84,31 @@ export default function App() {
     updateFrescoState();
     teleport('neutral')
   };
+
   const doAnswerYes = () => {
     dispatch(answerYes());
     updateFrescoState();
     teleport('neutral')
   };
+
+  useEffect(() => {
+    if (phase === GamePhase.STARTED) {
+      const yesListener =  fresco.subscribeToGlobalEvent('custom.reign.yes', () => {
+        doAnswerYes()
+      })
+
+      const noListener =  fresco.subscribeToGlobalEvent('custom.reign.no', () => {
+        doAnswerNo()
+      })
+
+      return () => {
+        yesListener();
+        noListener()
+      }
+    }
+  }, [phase])
+ 
+
   const doStartGame = () => {
     dispatch(startGame());
     updateFrescoState();

--- a/elements/reigns/src/fresco.d.ts
+++ b/elements/reigns/src/fresco.d.ts
@@ -9,15 +9,23 @@ interface IInitializeOptions {
     toolbarButtons: IToolbarButton[];
 }
 
+type AppearanceValue = string | number | boolean | Record<string, AppearanceValue>
+
 interface IFrescoSdk {
     onReady(callback: () => void): void;
     onStateChanged(callback: () => void): void;
     element: {
         state: any; 
+        id: string;
+        name: string;
+        appearance: Record<string, AppearanceValue>
     };
     setState(state: any): void;
     initialize(defaultState: any, options: IInitializeOptions): void;
+    send(action: {
+        type: string,
+        payload: any
+    }) : void
 }
-
 
 declare var fresco: IFrescoSdk;

--- a/elements/reigns/src/fresco.d.ts
+++ b/elements/reigns/src/fresco.d.ts
@@ -14,6 +14,7 @@ type AppearanceValue = string | number | boolean | Record<string, AppearanceValu
 interface IFrescoSdk {
     onReady(callback: () => void): void;
     onStateChanged(callback: () => void): void;
+    subscribeToGlobalEvent(eventName: string, handler: (event: any) => void): () => void
     element: {
         state: any; 
         id: string;


### PR DESCRIPTION
Hi,

this pr, on top of https://github.com/fres-co/fresco-community/pull/29, allows voting based on a global event dispatch in the same

- [ ]  need https://github.com/fres-co/fresco-community/pull/29 to be merged
- [ ] need a new SDK function to subscribe to global events