### PR TITLE
✨ Stop cursor changing

### DIFF
--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -4,6 +4,7 @@ body {
   background-color: #313e47;
   margin: 0;
   height: 100%;
+  user-select: none;
 }
 
 body,


### PR DESCRIPTION
Stops user selection of text within the extension, and thereby the cursor from changing to a caret.