### PR TITLE
Revert "remove debug log"

### DIFF
--- a/elements/reigns/src/features/host/hostSlice.ts
+++ b/elements/reigns/src/features/host/hostSlice.ts
@@ -33,6 +33,7 @@ const hostSlice = createSlice({
       };
 
       state.currentHost = determineHost(hostParams);
+      console.log('currentHost', state.currentHost);
       state.frescoUpdateCount = state.frescoUpdateCount + 1;
 
       if (


### PR DESCRIPTION
This reverts commit 11eec225fd1cc9b2bf4e823c6c250cd8781ffff4.

having the log to know who is the host is considered for now to be useful for debug purpose