### PR TITLE
:bug: :liptstick: fix game layout for default extension integration

### DIFF
--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -32,7 +32,7 @@ body,
 }
 
 .header__side {
-  flex: 1;
+  flex-grow: 1;
 }
 
 .header .round {
@@ -81,6 +81,19 @@ button {
   position: relative;
   padding: 0.25rem;
 }
+
+@media only screen and (max-width: 600px) {
+  .meters {
+    width: 200px;
+  }
+  .meter__icon {
+    width: 32px;
+    height: 32px;
+  }
+  .meters img {
+    height: 32px;
+  }
+}
 .meter {
   position: relative;
 }
@@ -120,6 +133,7 @@ button {
   display: flex;
   color: #fff;
   overflow: hidden;
+  min-height: 1px;
 }
 
 .question__text-wrap {


### PR DESCRIPTION
Hi,

currenlty when pasting `extension://fres-co.github.io/fresco-community/elements/reigns/dist/` inside a fres.co space,
we are unable to start a game.
the issue is because the default size of the extension does not give enough space for the text to fit.
Then the height of the HtmlDivElement we ar proving the textfit is 0, which lead to a crash.

This PR reduces the size of the resources in case the extension is too small, to give more room to the text