### PR TITLE
:sparkles: implement an infinit cards weight to discard other cards

### DIFF
--- a/elements/reigns/src/constants.ts
+++ b/elements/reigns/src/constants.ts
@@ -9,3 +9,5 @@ export enum Loading {
   Ended = "ended",
   Error = "error",
 }
+
+export const INFINITE_CARD_WEIGHT = 100;

--- a/elements/reigns/src/features/game/selectNextCard.test.ts
+++ b/elements/reigns/src/features/game/selectNextCard.test.ts
@@ -5,6 +5,7 @@ import { parseCardsFromCsv } from "./parseCardsFromCsv";
 import * as selectNextCard from "./selectNextCard";
 
 import { Card } from "./types";
+import { INFINITE_CARD_WEIGHT } from "../../constants";
 
 const {
   cardsDistributedByWeight,
@@ -31,6 +32,18 @@ describe("selectNextCard", () => {
 
       expect(result.filter((p) => p.card === "card1").length).toBe(1);
       expect(result.filter((p) => p.card === "card2").length).toBe(5);
+    });
+
+    it(`filter cards with weight of ${INFINITE_CARD_WEIGHT}`, () => {
+      const result = cardsDistributedByWeight([
+        { card: "card1", weight: 1 } as Card,
+        { card: "card2", weight: INFINITE_CARD_WEIGHT } as Card,
+        { card: "card3", weight: INFINITE_CARD_WEIGHT } as Card,
+      ]);
+
+      expect(result.filter((p) => p.card === "card1").length).toBe(0);
+      expect(result.filter((p) => p.card === "card2").length).toBe(1);
+      expect(result.filter((p) => p.card === "card3").length).toBe(1);
     });
   });
 

--- a/elements/reigns/src/features/game/selectNextCard.test.ts
+++ b/elements/reigns/src/features/game/selectNextCard.test.ts
@@ -30,8 +30,8 @@ describe("selectNextCard", () => {
         { card: "card2", weight: 5 } as Card,
       ]);
 
-      expect(result.filter((p) => p.card === "card1").length).toBe(1);
-      expect(result.filter((p) => p.card === "card2").length).toBe(5);
+      expect(result.filter((p) => p.card === "card1")).toHaveLength(1);
+      expect(result.filter((p) => p.card === "card2")).toHaveLength(5);
     });
 
     it(`filter cards with weight of ${INFINITE_CARD_WEIGHT}`, () => {
@@ -41,9 +41,9 @@ describe("selectNextCard", () => {
         { card: "card3", weight: INFINITE_CARD_WEIGHT } as Card,
       ]);
 
-      expect(result.filter((p) => p.card === "card1").length).toBe(0);
-      expect(result.filter((p) => p.card === "card2").length).toBe(1);
-      expect(result.filter((p) => p.card === "card3").length).toBe(1);
+      expect(result.filter((p) => p.card === "card1")).toHaveLength(0);
+      expect(result.filter((p) => p.card === "card2")).toHaveLength(1);
+      expect(result.filter((p) => p.card === "card3")).toHaveLength(1);
     });
   });
 

--- a/elements/reigns/src/features/game/selectNextCard.ts
+++ b/elements/reigns/src/features/game/selectNextCard.ts
@@ -1,9 +1,20 @@
-import { Card, GameDefinition, GameFlags, GameState } from "./types";
+import { Card, GameDefinition, GameFlags } from "./types";
 import { getConditions } from "./validateGameDefinition";
 import * as self from "./selectNextCard";
+import { INFINITE_CARD_WEIGHT } from "../../constants";
 
-export const cardsDistributedByWeight = (cards: Card[]) =>
-  cards.flatMap((card) => [...Array(card.weight).keys()].map(() => card));
+export const cardsDistributedByWeight = (cards: Card[]) => {
+  const cardWithMaximumWeights = cards.filter(
+    (card) => card.weight === INFINITE_CARD_WEIGHT
+  );
+  if (cardWithMaximumWeights.length > 0) {
+    return cardWithMaximumWeights;
+  }
+
+  return cards.flatMap((card) =>
+    [...Array(card.weight).keys()].map(() => card)
+  );
+};
 
 export const cardsRestrictedByFlags = (cards: Card[], gameFlags: GameFlags) =>
   cards.filter((card) => {


### PR DESCRIPTION
This PR implements a new feature,
where cards with of weight of `100` will be always picked over other cards.