### PR TITLE
✨ persist previous card ids only

### DIFF
--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -49,14 +49,14 @@ export class Game {
         state.definition,
         state.flags,
         state.designerCards,
-        state.previouslySelectedCards
+        state.previouslySelectedCardIds
       ),
       stats: state.definition
         ? state.definition.stats.map(({ value }) => value)
         : [],
       round: 1,
       flags: {},
-      previouslySelectedCards: [],
+      previouslySelectedCardIds: [],
     });
     return this;
   }

--- a/elements/reigns/src/features/game/gameSlice.ts
+++ b/elements/reigns/src/features/game/gameSlice.ts
@@ -25,7 +25,7 @@ export const initialState: GameState = {
   gameUrl: null,
   definition: null,
   round: 0,
-  previouslySelectedCards: [],
+  previouslySelectedCardIds: [],
 };
 
 export const gameSlice = createSlice({
@@ -38,7 +38,8 @@ export const gameSlice = createSlice({
       state.round = action.payload.round;
       state.selectedCard = action.payload.selectedCard;
       state.stats = action.payload.stats;
-      state.previouslySelectedCards = action.payload.previouslySelectedCards;
+      state.previouslySelectedCardIds =
+        action.payload.previouslySelectedCardIds;
     },
     setPhase: (state, action: PayloadAction<GamePhase>) => {
       state.phase = action.payload;

--- a/elements/reigns/src/features/game/selectAnswer.ts
+++ b/elements/reigns/src/features/game/selectAnswer.ts
@@ -45,12 +45,12 @@ export const selectAnswer = (
 
   const round = state.round + 1;
 
-  const previouslySelectedCards =
+  const previouslySelectedCardIds =
     phase === GamePhase.ENDED
       ? []
       : state.selectedCard
-      ? [state.selectedCard, ...state.previouslySelectedCards]
-      : state.previouslySelectedCards;
+      ? [state.selectedCard.id, ...state.previouslySelectedCardIds]
+      : state.previouslySelectedCardIds;
 
   const selectedCard =
     phase === GamePhase.ENDED
@@ -59,7 +59,7 @@ export const selectAnswer = (
           state.definition,
           flags,
           state.designerCards,
-          previouslySelectedCards
+          previouslySelectedCardIds
         );
 
   return {
@@ -68,7 +68,7 @@ export const selectAnswer = (
     stats,
     flags,
     selectedCard,
-    previouslySelectedCards,
+    previouslySelectedCardIds,
   };
 };
 

--- a/elements/reigns/src/features/game/selectNextCard.test.ts
+++ b/elements/reigns/src/features/game/selectNextCard.test.ts
@@ -10,8 +10,8 @@ import { INFINITE_CARD_WEIGHT } from "../../constants";
 const {
   cardsDistributedByWeight,
   cardsRestrictedByFlags,
-  isCardCooling,
-  removeCoolingCards,
+  isCardOnCooldown,
+  removeCardsOnCooldown,
 } = selectNextCard;
 
 describe("selectNextCard", () => {
@@ -107,9 +107,9 @@ describe("selectNextCard", () => {
     });
   });
 
-  describe("isCardCooling", () => {
+  describe("isCardOnCooldown", () => {
     it("returns false when no cards was proposed", () => {
-      const cardIsCooling = isCardCooling([], {
+      const cardIsCooling = isCardOnCooldown([], {
         card: "foo",
       } as Card);
 
@@ -118,28 +118,31 @@ describe("selectNextCard", () => {
 
     it("returns true when card was proposed and no cooldown", () => {
       const card = { card: "foo", id: "fooCard" } as Card;
-      const cardIsCooling = isCardCooling([card], card);
+      const cardIsCooling = isCardOnCooldown([card.id], card);
 
       expect(cardIsCooling).toBe(true);
     });
 
     it("returns false when card id different", () => {
       const card = { card: "foo", id: "fooCard" } as Card;
-      const cardIsCooling = isCardCooling([card], { ...card, id: "barCard" });
+      const cardIsCooling = isCardOnCooldown([card.id], {
+        ...card,
+        id: "barCard",
+      });
 
       expect(cardIsCooling).toBe(false);
     });
 
     it("returns false when card was just played and cooldown is 0", () => {
       const card = { card: "foo", cooldown: 0 } as Card;
-      const cardIsCooling = isCardCooling([card], card);
+      const cardIsCooling = isCardOnCooldown([card.id], card);
 
       expect(cardIsCooling).toBe(false);
     });
 
     it("returns true when card was just played and cooldown is 1", () => {
       const card = { card: "foo", cooldown: 1 } as Card;
-      const cardIsCooling = isCardCooling([card], card);
+      const cardIsCooling = isCardOnCooldown([card.id], card);
 
       expect(cardIsCooling).toBe(true);
     });
@@ -149,25 +152,28 @@ describe("selectNextCard", () => {
         { card: "bar", cooldown: 1, id: "card-bar" } as Card,
         { card: "foo", cooldown: 1, id: "card-foo" } as Card,
       ];
-      const cardIsCooling = isCardCooling(cards, cards[1]);
+      const cardIsCooling = isCardOnCooldown(
+        cards.map((c) => c.id),
+        cards[1]
+      );
 
       expect(cardIsCooling).toBe(false);
     });
   });
 
-  describe("removeCoolingCards", () => {
+  describe("removeCardsOnCooldown", () => {
     it("returns original cards array for first round", () => {
       const cards = [
         { card: "card1", cooldown: 1, id: "card-1" } as Card,
         { card: "card2", id: "card-2" } as Card,
       ];
 
-      const filteredCards = removeCoolingCards(cards, []);
+      const filteredCards = removeCardsOnCooldown(cards, []);
 
       expect(filteredCards).toEqual(cards);
     });
 
-    it("removes cards where isCardCooling function returns true", () => {
+    it("removes cards where isCardOnCooldown function returns true", () => {
       const cards = [
         { card: "card1", id: "card-1", cooldown: 1 } as Card,
         { card: "card2", id: "card-2" } as Card,
@@ -175,25 +181,23 @@ describe("selectNextCard", () => {
         { card: "card4", id: "card-4" } as Card,
       ];
 
-      const isCardCoolingSpy = jest
-        .spyOn(selectNextCard, "isCardCooling")
+      const isCardOnCooldownSpy = jest
+        .spyOn(selectNextCard, "isCardOnCooldown")
         .mockImplementation(
           (_, card: Card) => card.card === "card2" || card.card === "card3"
         );
-      const filteredCards = removeCoolingCards(cards, [
-        { card: "hotcards" } as Card,
-      ]);
+      const filteredCards = removeCardsOnCooldown(cards, ["any-id"]);
 
       expect(filteredCards).toEqual([cards[0], cards[3]]);
 
-      isCardCoolingSpy.mockRestore();
+      isCardOnCooldownSpy.mockRestore();
     });
   });
 
   describe("Cooling integration", () => {
     const cards = parseCardsFromCsv(`
 card,id,bearer,conditions,cooldown,weight,override_yes,answer_yes,yes_stat1,yes_stat2,yes_stat3,yes_stat4,yes_custom,answer_no,no_stat1,no_stat2,no_stat3,no_stat4,no_custom
-cooldown-3,,entrepreneur,,3,100,,Explore,0,0,0,0,,Gather,-500,-500,-500,,
+cooldown-2,,entrepreneur,,2,100,,Explore,0,0,0,0,,Gather,-500,-500,-500,,
 cooldown-0,,customer-support,,0,1,,Fight it,0,0,0,0,,Flee,-500,-500,-500,,`);
     it("selected first card", () => {
       console.log("cards are", cards);
@@ -205,7 +209,7 @@ cooldown-0,,customer-support,,0,1,,Fight it,0,0,0,0,,Flee,-500,-500,-500,,`);
         .retrieve();
 
       expect(result).toBeDefined();
-      expect(result?.selectedCard?.card).toBe("cooldown-3");
+      expect(result?.selectedCard?.card).toBe("cooldown-2");
 
       new Game().answerYes(createGameState(gameDefinition, result));
 
@@ -216,6 +220,11 @@ cooldown-0,,customer-support,,0,1,,Fight it,0,0,0,0,,Flee,-500,-500,-500,,`);
 
       const afterSecondAnswer = new Game().retrieve();
       expect(afterSecondAnswer?.selectedCard?.card).toBe("cooldown-0");
+
+      new Game().answerYes(createGameState(gameDefinition, afterSecondAnswer));
+
+      const afterThirdAnswer = new Game().retrieve();
+      expect(afterThirdAnswer?.selectedCard?.card).toBe("cooldown-2");
     });
   });
 });

--- a/elements/reigns/src/features/game/selectNextCard.ts
+++ b/elements/reigns/src/features/game/selectNextCard.ts
@@ -33,7 +33,7 @@ const getAllValidCards = (
   definition: GameDefinition | null,
   flags: GameFlags,
   designerCards: Card[] | null = null,
-  previouslySelectedCards: Card[]
+  previouslySelectedCardIds: string[]
 ) => {
   if (!definition) {
     return [];
@@ -43,9 +43,9 @@ const getAllValidCards = (
     flags
   );
 
-  const availableCards = removeCoolingCards(
+  const availableCards = removeCardsOnCooldown(
     restrictedByFlags,
-    previouslySelectedCards
+    previouslySelectedCardIds
   );
 
   return cardsDistributedByWeight(availableCards);
@@ -55,13 +55,13 @@ export const selectNextCard = (
   definition: GameDefinition | null,
   flags: GameFlags,
   designerCards: Card[] | undefined,
-  previouslySelectedCards: Card[]
+  previouslySelectedCardIds: string[]
 ) => {
   const validCards = getAllValidCards(
     definition,
     flags,
     designerCards,
-    previouslySelectedCards
+    previouslySelectedCardIds
   );
 
   const randomCard = validCards[Math.floor(Math.random() * validCards.length)];
@@ -71,40 +71,42 @@ export const selectNextCard = (
   };
 };
 
-export const removeCoolingCards = (
+export const removeCardsOnCooldown = (
   allCards: Card[],
-  previousCardRounds: Card[]
+  previouslySelectedCardIds: string[]
 ) => {
-  if (previousCardRounds.length === 0) {
+  if (previouslySelectedCardIds.length === 0) {
     return allCards;
   }
 
-  const coldCards = allCards.filter(
-    (card) => !self.isCardCooling(previousCardRounds, card)
+  const cardsNotOnCooldown = allCards.filter(
+    (card) => !self.isCardOnCooldown(previouslySelectedCardIds, card)
   );
 
-  if (coldCards.length > 0) {
-    return coldCards;
+  if (cardsNotOnCooldown.length > 0) {
+    return cardsNotOnCooldown;
   }
 
   return allCards;
 };
 
-export function isCardCooling(previousCardRounds: Card[], card: Card): boolean {
-  const round = previousCardRounds.length + 1;
+export function isCardOnCooldown(
+  previouslySelectedCardIds: string[],
+  card: Card
+): boolean {
+  const round = previouslySelectedCardIds.length + 1;
 
-  const lastPlayedIndex = previousCardRounds.findIndex(
-    (previousCard) => previousCard.id === card.id
+  const lastPlayedIndex = previouslySelectedCardIds.findIndex(
+    (id) => id === card.id
   );
 
   if (lastPlayedIndex === -1) {
-    // card was not never selected
+    // card was never played
     return false;
   }
-  const previousCard = previousCardRounds[lastPlayedIndex];
 
-  const cooldownValue = previousCard.cooldown ?? Infinity;
-  const lastVisibleRound = previousCardRounds.length - lastPlayedIndex;
+  const cooldownValue = card.cooldown ?? Infinity;
+  const lastPlayedRound = previouslySelectedCardIds.length - lastPlayedIndex;
 
-  return !(round > lastVisibleRound + cooldownValue);
+  return !(round > lastPlayedRound + cooldownValue);
 }

--- a/elements/reigns/src/features/game/types.ts
+++ b/elements/reigns/src/features/game/types.ts
@@ -58,7 +58,7 @@ export type PersistedGameState = {
   stats: number[];
   round: number;
   flags: GameFlags;
-  previouslySelectedCards: Card[]; // array sorted in the reverse order, recently viewed card have the lowest index
+  previouslySelectedCardIds: string[]; // array sorted in the reverse order, recently viewed card have the lowest index
 };
 
 export type PersistedState = Configuration & PersistedGameState;

--- a/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
+++ b/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
@@ -27,7 +27,7 @@ export const useOnFrescoStateUpdate = () => {
           round: state.round,
           selectedCard: state.selectedCard,
           stats: state.stats,
-          previouslySelectedCards: state.previouslySelectedCards,
+          previouslySelectedCardIds: state.previouslySelectedCardIds,
         })
       );
     } else {


### PR DESCRIPTION
https://mobitroll.atlassian.net/browse/FRES-1363

Reduces realtime packet size by switching `previouslySelectedCards: Card[]` to `previouslySelectedCardIds: string[]`.

Additional optimisations could be considered later:

- removing custom ids and switching from `id: string` to `id: number`
- switching `selectedCard: Card` to `selectedCardId: string`