### PR TITLE
Fix/fres 1163 loading demo json

### DIFF
--- a/elements/reigns/src/features/game/parseCardsFromCsv.ts
+++ b/elements/reigns/src/features/game/parseCardsFromCsv.ts
@@ -2,7 +2,7 @@ import * as Papa from "papaparse";
 import { Card } from "./types";
 
 export const mapCardWithIndex = (card: Card, index: number) => {
-  if (card.id !== "" && card.id !== null) {
+  if (card.id !== "" && card.id !== null && card.id !== undefined) {
     return { ...card, id: `${card.id}` };
   }
 

--- a/elements/reigns/src/features/game/parseCardsFromCsv.ts
+++ b/elements/reigns/src/features/game/parseCardsFromCsv.ts
@@ -1,6 +1,14 @@
 import * as Papa from "papaparse";
 import { Card } from "./types";
 
+export const mapCardWithIndex = (card: Card, index: number) => {
+  if (card.id !== "" && card.id !== null) {
+    return { ...card, id: `${card.id}` };
+  }
+
+  return { ...card, id: `index-${index}` };
+};
+
 export const parseCardsFromCsv = (
   csvData: string | undefined
 ): Card[] | undefined => {
@@ -15,11 +23,5 @@ export const parseCardsFromCsv = (
     throw new Error(parsedData.errors[0].message);
   }
 
-  return (parsedData.data as Card[]).map((card: Card, index) => {
-    if (card.id !== '' && card.id !== null) {
-      return { ...card, id: `${card.id}` }
-    }
-
-    return { ...card, id: `index-${index}`}
-  }) as Card[];
+  return (parsedData.data as Card[]).map(mapCardWithIndex) as Card[];
 };

--- a/elements/reigns/src/features/game/validateGameDefinition.test.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.test.ts
@@ -4,6 +4,7 @@ import {
   getFlags,
   validateFlags,
   getConditions,
+  validateGameDefinition,
 } from "./validateGameDefinition";
 import gdpr from "../../../public/games/gdpr.json";
 import dont_starve from "../../../public/games/dont-starve.json";
@@ -20,6 +21,7 @@ describe("validateGameDefinition", () => {
         ])
       ).not.toThrow();
     });
+
     it("should throw if no cards", () => {
       expect(() => validateCards([])).toThrow();
     });
@@ -192,6 +194,53 @@ describe("validateGameDefinition", () => {
       const iterator = dont_starve.cards.values();
       const cards: Card[] = Array.from(iterator);
       expect(() => validateCards(cards)).not.toThrow();
+    });
+  });
+
+  describe("validateGameDefinition", () => {
+    it("should returns cards provided with id", () => {
+      const definitionCards = [
+        { card: "foo", id: "fooId", weight: 1 },
+        { card: "bar", id: "barId", weight: 1 },
+      ] as Card[];
+      const gameDefinition = validateGameDefinition({
+        cards: definitionCards,
+        stats: [{ name: "foo", value: 0, icon: "" }],
+        assetsUrl: "",
+        deathMessage: "Sorry",
+        roundName: "day",
+        gameName: "Welcome",
+      });
+
+      expect(gameDefinition.cards).toEqual(definitionCards);
+    });
+
+    it("should generate ids for cards without id", () => {
+      const definitionCards = [
+        { card: "foo", weight: 1 },
+        { card: "bar", id: "barId", weight: 1 },
+        { card: "baz", weight: 1 },
+      ] as Card[];
+
+      const gameDefinition = validateGameDefinition({
+        cards: definitionCards,
+        stats: [{ name: "foo", value: 0, icon: "" }],
+        assetsUrl: "",
+        deathMessage: "Sorry",
+        roundName: "day",
+        gameName: "Welcome",
+      });
+
+      expect(gameDefinition.cards.length).toBe(3);
+      expect(gameDefinition.cards[0]).toEqual({
+        ...definitionCards[0],
+        id: "index-0",
+      });
+      expect(gameDefinition.cards[1]).toEqual(definitionCards[1]);
+      expect(gameDefinition.cards[2]).toEqual({
+        ...definitionCards[2],
+        id: "index-2",
+      });
     });
   });
 });

--- a/elements/reigns/src/features/game/validateGameDefinition.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.ts
@@ -10,7 +10,7 @@ export const validateGameDefinition = (
   return {
     ...definition,
     assetsUrl: getRootAssetsUrl(definition.assetsUrl),
-    ...validateCards(cardsWithIds),
+    cards: validateCards(cardsWithIds),
   };
 };
 

--- a/elements/reigns/src/features/game/validateGameDefinition.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.ts
@@ -1,13 +1,18 @@
 import { getRootAssetsUrl } from "./gameDefinitionUtils";
+import { mapCardWithIndex } from "./parseCardsFromCsv";
 import { Card, CardFlag, GameDefinition } from "./types";
 
 export const validateGameDefinition = (
   definition: GameDefinition
-): GameDefinition => ({
-  ...definition,
-  assetsUrl: getRootAssetsUrl(definition.assetsUrl),
-  ...validateCards(definition.cards),
-});
+): GameDefinition => {
+  const cardsWithIds = definition.cards.map(mapCardWithIndex);
+
+  return {
+    ...definition,
+    assetsUrl: getRootAssetsUrl(definition.assetsUrl),
+    ...validateCards(cardsWithIds),
+  };
+};
 
 export const urlWithoutTrailingSlash = (url: string) => {
   if (!url) return "";


### PR DESCRIPTION
this PR fixes the loading a reign instance with the `game/demo.json` definition.

it currently fails because of ids not being provided nor being generated.
The generation was done only in the `parseCardsFromCsv`.
this PR fixes it.