### PR TITLE
:memo: add new sdk triggerEvent function doc

### DIFF
--- a/elements/README.md
+++ b/elements/README.md
@@ -133,6 +133,6 @@ The second one is `options` which accepts the following values:
 - `color`: a string to describe the text color of the message
 - `background`: a string to describe the background color or the message
 
-## Subscribing to space events
+## Subscribing and trigger space events
 
 See [fresco.d.ts](reigns/src/fresco.d.ts).

--- a/elements/reigns/src/fresco.d.ts
+++ b/elements/reigns/src/fresco.d.ts
@@ -56,6 +56,11 @@ interface IFrescoSdk {
     eventName: string,
     handler: (event: any) => void
   ): () => void;
+
+  triggerEvent(event: {
+    eventName: string;
+    eventValue: undefined | boolean | string | number;
+  }): void;
   element: {
     state: any;
     id: string;


### PR DESCRIPTION
this PR adds the doc for the new triggerEvent function accessible through fresco SDK.

marking as draft as the `triggerEvent` function ins not yet available