### PR TITLE
Fix/fres 1379 flags no reset restart

### DIFF
--- a/elements/reigns/src/features/game/Game.test.ts
+++ b/elements/reigns/src/features/game/Game.test.ts
@@ -69,7 +69,40 @@ describe("Game", () => {
 
         expect(game.retrieve().flags.chapter3).toBe(undefined);
       });
+
+
+      it('should select first cards no matter or previous flags', () => {
+
+        const game = new Game();
+        const prevState = createGameState(createGameDefinition(), {
+          flags: {
+            chapter3: "true",
+          },
+        });
+        getSdk().storage.realtime.set(GAME_TABLE, GAME_STATE_KEY, prevState);
+        expect(game.retrieve().flags.chapter3).toBe("true");
+
+        const newGameState = createGameState(createGameDefinition({
+          cards: [
+            createCard({ card: 'initial card'}),
+            createCard({ card: 'chapter 3 intro', conditions: 'chapter3==true'})
+          ]
+        }), {
+          flags: {
+            chapter3: "true",
+          },
+        });
+
+        game.startGame(newGameState);
+
+        const results = game.retrieve()
+        expect(results.flags.chapter3).toBe(undefined);
+
+        expect(results.selectedCard?.card).toBe("initial card");
+        expect(results.round).toBe(1);
+      })
     });
+
     describe("answerYes", () => {
       it("should select a card", () => {
         const result = new Game()

--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -41,7 +41,8 @@ export class Game {
     this.clearVotes();
   }
 
-  startGame(state: GameState) {
+  startGame(state: Pick<GameState, 'definition' | 'designerCards'>) {
+    debugger;
     this.clearVotes();
     const flags = {};
     const previouslySelectedCardIds = [] as string[];

--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -43,20 +43,22 @@ export class Game {
 
   startGame(state: GameState) {
     this.clearVotes();
+    const flags = {};
+    const previouslySelectedCardIds = [] as string[];
     this.persist({
       phase: GamePhase.STARTED,
       selectedCard: selectNextCard(
         state.definition,
-        state.flags,
+        flags,
         state.designerCards,
-        state.previouslySelectedCardIds
+        previouslySelectedCardIds
       ),
       stats: state.definition
         ? state.definition.stats.map(({ value }) => value)
         : [],
       round: 1,
-      flags: {},
-      previouslySelectedCardIds: [],
+      flags,
+      previouslySelectedCardIds,
     });
     return this;
   }

--- a/elements/reigns/src/features/game/selectNextCard.ts
+++ b/elements/reigns/src/features/game/selectNextCard.ts
@@ -57,6 +57,7 @@ export const selectNextCard = (
   designerCards: Card[] | undefined,
   previouslySelectedCardIds: string[]
 ) => {
+  debugger;
   const validCards = getAllValidCards(
     definition,
     flags,

--- a/elements/reigns/src/features/game/validateGameDefinition.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.ts
@@ -7,11 +7,11 @@ export const validateGameDefinition = (
 ): GameDefinition => {
   const cardsWithIds = definition.cards.map(mapCardWithIndex);
 
-  return {
+  return Object.freeze({
     ...definition,
     assetsUrl: getRootAssetsUrl(definition.assetsUrl),
     cards: validateCards(cardsWithIds),
-  };
+  });
 };
 
 export const urlWithoutTrailingSlash = (url: string) => {


### PR DESCRIPTION
this PR fixes a bug with the Reigns game, where restarting a game would pick a wrong card.
I added a unit test, and confirmed it was failing before the fix

# Repro
- Start the GDPR game and answer a number of questions
- Paste some CSV into designerCards and click Ok (Game restarts)
- Remove the CSV data from designerCards and click Ok (Game restarts)
- Click Start Game

# Expected
First card displayed

# Actual
A card from the step #1 session is displayed

