### PR TITLE
:sparkles: allow to load a full csv definition

### DIFF
--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -42,7 +42,6 @@ export class Game {
   }
 
   startGame(state: Pick<GameState, "definition" | "designerCards">) {
-    debugger;
     this.clearVotes();
     const flags = {};
     const previouslySelectedCardIds = [] as string[];

--- a/elements/reigns/src/features/game/gameSlice.ts
+++ b/elements/reigns/src/features/game/gameSlice.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { GamePhase, Loading } from "../../constants";
 import { parseCardsFromCsv } from "./parseCardsFromCsv";
+import { parseGameFromCsv } from "./parseGameFromCsv";
 import { Configuration, GameState, PersistedGameState } from "./types";
 import {
   validateCards,
@@ -11,6 +12,12 @@ export const initializeGame = createAsyncThunk(
   "game/initializeGame",
   async (gameUrl: string) => {
     const response = await fetch(gameUrl);
+
+    if (gameUrl.endsWith("csv")) {
+      const csv = await response.text();
+      return parseGameFromCsv(csv);
+    }
+
     const json = await response.json();
     return json;
   }

--- a/elements/reigns/src/features/game/parseCardsFromCsv.ts
+++ b/elements/reigns/src/features/game/parseCardsFromCsv.ts
@@ -9,9 +9,8 @@ export const mapCardWithIndex = (card: Card, index: number) => {
   return { ...card, id: `index-${index}` };
 };
 
-export const parseCardsFromCsv = (
-  csvData: string | undefined
-): Card[] | undefined => {
+export const parseSectionFromCsv = <T>(csvData: string| undefined) => {
+
   if (!csvData) return;
   const parsedData = Papa.parse(csvData, {
     header: true,
@@ -23,5 +22,15 @@ export const parseCardsFromCsv = (
     throw new Error(parsedData.errors[0].message);
   }
 
-  return (parsedData.data as Card[]).map(mapCardWithIndex) as Card[];
+  return (parsedData.data as T[])
+
+}
+
+export const parseCardsFromCsv = (
+  csvData: string | undefined
+): Card[] | undefined => {
+  const parsedSection = parseSectionFromCsv<Card>(csvData)
+  if(!parsedSection) { return undefined }
+
+  return parsedSection.map(mapCardWithIndex) as Card[];
 };

--- a/elements/reigns/src/features/game/parseGameFromCsv.test.ts
+++ b/elements/reigns/src/features/game/parseGameFromCsv.test.ts
@@ -1,0 +1,72 @@
+import { parseGameFromCsv } from "./parseGameFromCsv";
+import { GameDefinition } from "./types";
+
+const data = `SECTION,,,,,,,,,,,,,,,,,,,
+main,gameName,deathMessage,roundName,assetsUrl,,,,,,,,,,,,,,,
+,A month in the life of a data officer,You have been fired!,Day,games,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,
+stats,name,icon,value,,,,,,,,,,,,,,,,
+,Profit,noun-coins-1123601.svg,50,,,,,,,,,,,,,,,,
+,Customer satisfaction,noun-crowd-2383331.svg,37,,,,,,,,,,,,,,,,
+,Security,noun-shield-4865890.svg,5,,,,,,,,,,,,,,,,
+,Team well-being,noun-team-4854330.svg,78,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,
+cards,card,id,bearer,conditions,churn,weight,override_yes,answer_yes,yes_stat1,yes_stat2,yes_stat3,yes_stat4,yes_custom,answer_no,no_stat1,no_stat2,no_stat3,no_stat4,no_custom
+,"Data officer, we want to test a new product. Is it ok to ignore GDPR practices for now?",card-1,entrepreneur,,2,10,,Yes but keep me in the loop,5,5,-10,0,,Absolutely not!,-5,-5,0,42,
+,One of our clients is asking to get his data deleted,card-2,customer-support,,2,1,,,10,-5,10,0,,,-10,0,-10,,
+,"Our database queries are getting slower, we should do something about our old data",card-3,developer,,2,1,,Delete data from inactive users,0,0,10,0,,Extract the data and archive it,-5,0,-10,,
+,A potential acquirer is asking for the content of our data.,card-4,customer-support,,2,1,,"Of course, this could be a great opportunity for us",-10,0,-10,0,0,Hell no!,0,-5,0,,
+,We have been breached. The password hashes of our users have been published online!,card-5,developer,,2,1,,Send an apology to our users and explain we are going to enforce Multi Factor authentication.,5,-10,-5,0,,Sshhh... Let's hope the news doesn't spread,-5,-5,-5,,cheated=true
+,A security consultant has (unsolicitedly) reported a new vulnerability.,card-6,customer-support,,2,100,,Pay this person a bounty and fix the bug asap,0,-5,10,0,,Ignore this person. These guys are vultures.,-5,0,-10,,
+,Our users complain it is too hard to cancel our subscription,card-7,customer-support,,2,1,,"It is by design, so that we can make them change their mind.",-5,10,-5,0,,Add a new button to start the cancelation process,5,0,10,,
+,"The EU commission is not happy, they found out about your little data breach...",card-8,entrepreneur,cheated==true stat3<20,2,80,,Damn...,-10,0,-10,0,,Oopsie...,-10,0,-10,,cheated=false`;
+
+describe("parseGameFromCsv", () => {
+  it("should parse cards from string", () => {
+    const { cards } = parseGameFromCsv(data) || { cards: [] };
+    expect(cards.length).toBe(8);
+
+    expect(cards[0].card).toBe(
+      "Data officer, we want to test a new product. Is it ok to ignore GDPR practices for now?"
+    );
+    expect(cards[0]["no_stat4"]).toBe(42);
+
+    expect(cards[7].card).toBe(
+      "The EU commission is not happy, they found out about your little data breach..."
+    );
+    expect(cards[7]["no_stat4"]).toBe(null);
+    expect(cards[7]["no_custom"]).toBe("cheated=false");
+  });
+
+  it("should parse stats from string", () => {
+    const { stats } = parseGameFromCsv(data) || { stats: [] };
+    expect(stats.length).toBe(4);
+
+    expect(stats[0].name).toBe("Profit");
+    expect(stats[0].icon).toBe("noun-coins-1123601.svg");
+    expect(stats[0].value).toBe(50);
+
+    expect(stats[1].name).toBe("Customer satisfaction");
+    expect(stats[1].icon).toBe("noun-crowd-2383331.svg");
+    expect(stats[1].value).toBe(37);
+
+    expect(stats[2].name).toBe("Security");
+    expect(stats[2].icon).toBe("noun-shield-4865890.svg");
+    expect(stats[2].value).toBe(5);
+
+    expect(stats[3].name).toBe("Team well-being");
+    expect(stats[3].icon).toBe("noun-team-4854330.svg");
+    expect(stats[3].value).toBe(78);
+  });
+
+  it("should parse main section from string", () => {
+    const { gameName, deathMessage, roundName, assetsUrl } = parseGameFromCsv(
+      data
+    ) as GameDefinition;
+
+    expect(gameName).toBe("A month in the life of a data officer");
+    expect(deathMessage).toBe("You have been fired!");
+    expect(roundName).toBe("Day");
+    expect(assetsUrl).toBe("games");
+  });
+});

--- a/elements/reigns/src/features/game/parseGameFromCsv.ts
+++ b/elements/reigns/src/features/game/parseGameFromCsv.ts
@@ -1,0 +1,73 @@
+import * as Papa from "papaparse";
+import { Game } from "./Game";
+import { parseCardsFromCsv, parseSectionFromCsv } from "./parseCardsFromCsv";
+import { Card, GameDefinition } from "./types";
+
+export const parseGameFromCsv = (
+  csvData: string | undefined
+): GameDefinition | undefined => {
+  if (!csvData) return;
+  const parsedData = Papa.parse<string[]>(csvData, {
+    skipEmptyLines: true,
+  });
+
+  if (parsedData.errors.length > 0) {
+    throw new Error(parsedData.errors[0].message);
+  }
+
+  const main = getCSVSection(parsedData, "main");
+  const csvStats = getCSVSection(parsedData, "stats");
+  const csvCards = getCSVSection(parsedData, "cards");
+
+  const mainGameDefinition = parseSectionFromCsv<GameDefinition>(main)?.[0] ?? {
+    assetsUrl: "",
+    roundName: "",
+    gameName: "",
+    deathMessage: "",
+  };
+
+  const gameDefinition: GameDefinition = {
+    ...mainGameDefinition,
+    cards: parseCardsFromCsv(csvCards) || [],
+    stats: parseSectionFromCsv(csvStats) || [],
+  };
+
+  return gameDefinition;
+};
+
+const getCSVSection = (
+  parsedData: Papa.ParseResult<string[]>,
+  sectionName: string
+) => {
+  console.log("parsedDate", parsedData);
+  const sectionNameColumn = parsedData.data[0]?.findIndex(
+    (value: string) => value === "SECTION"
+  );
+
+  const startSectionIndex = parsedData.data.findIndex((line) => {
+    return line[sectionNameColumn] === sectionName;
+  });
+
+  let endSectionIndex = parsedData.data
+    .slice(startSectionIndex + 1)
+    .findIndex((line) => {
+      console.log(
+        "line[sectionNameColumn]",
+        line[sectionNameColumn],
+        line[sectionNameColumn] === ""
+      );
+      return line[sectionNameColumn] !== "";
+    });
+
+  console.log("maxired endSectionIndex is", endSectionIndex);
+  if (endSectionIndex === -1) {
+    endSectionIndex = parsedData.data.length;
+  }
+
+  const sectionData = parsedData.data
+    .slice(startSectionIndex, endSectionIndex + startSectionIndex)
+    .map((line) => line.slice(sectionNameColumn + 1));
+
+  console.log("maxired sectionData", sectionData);
+  return Papa.unparse(sectionData);
+};

--- a/elements/reigns/src/features/game/parseGameFromCsv.ts
+++ b/elements/reigns/src/features/game/parseGameFromCsv.ts
@@ -39,7 +39,6 @@ const getCSVSection = (
   parsedData: Papa.ParseResult<string[]>,
   sectionName: string
 ) => {
-  console.log("parsedDate", parsedData);
   const sectionNameColumn = parsedData.data[0]?.findIndex(
     (value: string) => value === "SECTION"
   );
@@ -50,16 +49,8 @@ const getCSVSection = (
 
   let endSectionIndex = parsedData.data
     .slice(startSectionIndex + 1)
-    .findIndex((line) => {
-      console.log(
-        "line[sectionNameColumn]",
-        line[sectionNameColumn],
-        line[sectionNameColumn] === ""
-      );
-      return line[sectionNameColumn] !== "";
-    });
+    .findIndex((line) => line[sectionNameColumn] !== "");
 
-  console.log("maxired endSectionIndex is", endSectionIndex);
   if (endSectionIndex === -1) {
     endSectionIndex = parsedData.data.length;
   }
@@ -68,6 +59,5 @@ const getCSVSection = (
     .slice(startSectionIndex, endSectionIndex + startSectionIndex)
     .map((line) => line.slice(sectionNameColumn + 1));
 
-  console.log("maxired sectionData", sectionData);
   return Papa.unparse(sectionData);
 };


### PR DESCRIPTION
Hi,

this PR allows using a single CSV file for a full game definition.

here is a sample of a csv file that can be loaded https://docs.google.com/spreadsheets/d/e/2PACX-1vRHeFFu_3HnSy5L_xcWeq-1cAdTLRiOuGD83EEbdiw6UFcIvJWiXLMA0l08O6L-rRC3W0Ur8qBbewb2/pub?output=csv

Here is the public Google spreadsheet file used as a backend.
https://docs.google.com/spreadsheets/d/17HXDBv5ZdLGw8R-Tf1Rf1PeyRQlt5PBmDXPFwa6DnDE/edit#gid=127106150

the idea is to help create a new game without ever touching JSON.