### PR TITLE
:liptsick: fix safari timer input visibility

### DIFF
--- a/elements/timer/index.css
+++ b/elements/timer/index.css
@@ -69,15 +69,21 @@ p {
   font-weight: 700;
   font-family: "Quicksand", sans-serif;
   text-align: center;
-  height: 110px;
   width: 156px;
-  padding-bottom: 6px;
   border: none;
   caret-color: #9e32d6;
 }
 
+p {
+  height: 110px;
+  padding-bottom: 24px;
+}
+
 input {
   text-align: right;
+  text-align: right;
+  line-height: 1.2em;
+  height: 1.2em;
 }
 
 input::-webkit-outer-spin-button,
@@ -97,6 +103,7 @@ input:hover:not(:disabled) {
   display: flex;
   align-items: flex-end;
   padding-top: 18px;
+  margin-bottom: -24px;
 }
 
 .buttons-group {
@@ -171,8 +178,10 @@ input:hover:not(:disabled) {
   input,
   p {
     font-size: 80px;
-    height: 70px;
     width: 100px;
+  }
+  p {
+    height: 70px;
   }
   .timer p {
     height: 80px;
@@ -193,8 +202,11 @@ input:hover:not(:disabled) {
   input,
   p {
     font-size: 55px;
-    height: 50px;
+
     width: 70px;
+  }
+  p {
+    height: 50px;
   }
 
   .buttons-group {

--- a/elements/timer/index.css
+++ b/elements/timer/index.css
@@ -92,6 +92,10 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 input:focus,
 input:hover:not(:disabled) {
   background: #f2f2f2;

--- a/elements/timer/index.css
+++ b/elements/timer/index.css
@@ -160,7 +160,6 @@ input:hover:not(:disabled) {
 }
 
 .user form {
-  flex-direction: row;
   padding-bottom: 5px;
 }
 


### PR DESCRIPTION
![d15052af-83f9-400c-b36c-97a6103e576c](https://user-images.githubusercontent.com/1194083/179785248-cae6f788-8a69-48ca-a90e-8a83cbd17f0e.png)


this Pr fixes the fact that the timer input is not correct on safari.
this is due to the fact that safari does not vertically center the input content, when specifying an `height` on it