### PR TITLE
:lipstick: use real arrow symbol for ressource impact

### DIFF
--- a/elements/reigns/src/MeterArrow.tsx
+++ b/elements/reigns/src/MeterArrow.tsx
@@ -10,7 +10,7 @@ export const MeterArrow = ({
   const textRef = useRef("\u00a0"); // default value of insecapable space to have initial height
 
   if (currentAnimation !== "") {
-    let nextText = currentAnimation.includes("--grow") ? ">" : "<";
+    let nextText = currentAnimation.includes("--grow") ? "▶" : "◀";
     if (currentAnimation.includes("--big")) {
       nextText += nextText;
     }

--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -91,8 +91,9 @@ button {
 
 .meter__arrow {
   font-weight: bold;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 24px;
+  padding-top: 5px;
   transition: opacity 0.3s ease, color 0s var(--stats-color-transition-duration); /* remove color after the opacity transition */
   opacity: 0;
   color: var(--color-primary);


### PR DESCRIPTION
this PR updates the symbol used for the arrow resources of the story-quizz element.
this now looks more like an arrow,

<img width="1440" alt="Screenshot 2022-07-21 at 16 35 32" src="https://user-images.githubusercontent.com/1194083/180240869-66c35aff-38a5-48e5-8896-f4832b725a6d.png">
