### PR TITLE
Fix/fres 1501 teleporting only when playing

### DIFF
--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -35,7 +35,13 @@ export class Game {
   }
 
   changeGame() {
-    getSdk().storage.realtime.set(GAME_TABLE, GAME_STATE_KEY, undefined);
+    getSdk().storage.realtime.set(GAME_TABLE, GAME_STATE_KEY, {
+      phase: GamePhase.NOT_STARTED,
+      selectedCard: null,
+      round: 0,
+      flags: {},
+      stats: []
+    });
     this.clearVotes();
   }
 

--- a/elements/reigns/src/features/game/gameSlice.ts
+++ b/elements/reigns/src/features/game/gameSlice.ts
@@ -69,7 +69,9 @@ export const gameSlice = createSlice({
   extraReducers(builder) {
     builder
       .addCase(initializeGame.pending, (state) => {
+        state= {...initialState, gameUrl: state.gameUrl}
         state.loading = Loading.InProgress;
+
         console.log("GAME", "loading");
       })
       .addCase(initializeGame.fulfilled, (state, action) => {

--- a/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
+++ b/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
@@ -38,7 +38,7 @@ export const useOnFrescoStateUpdate = () => {
     const state = new Game().retrieve();
 
     if (state) {
-      if (state.round > prevState.game.round) {
+      if (state.round > prevState.game.round || state.phase !== prevState.game.phase) {
         if (!prevState.transition.round) {
           void animateRoundTransition(
             dispatch,
@@ -86,7 +86,12 @@ const animateRoundTransition = async (
   dispatch(startRoundTransition());
   if (!immediate) {
     await wait(TELEPORT_START_DELAY);
+  }
+  if (getSdk().localParticipant.isInsideElement) {
+    // maybe participant is only looking at the game
     teleport("neutral");
+  }
+  if (!immediate) {
     await wait(RESOURCE_CHANGE_DELAY);
   }
   dispatch(updateGame({ ...storedState.game, stats: state.stats }));

--- a/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
+++ b/elements/reigns/src/features/voting/useOnFrescoStateUpdate.ts
@@ -38,13 +38,13 @@ export const useOnFrescoStateUpdate = () => {
     const state = new Game().retrieve();
 
     if (state) {
-      if (state.round > prevState.game.round || state.phase !== prevState.game.phase) {
+      if (state.phase !== GamePhase.NOT_STARTED && (state.round > prevState.game.round || state.phase !== prevState.game.phase)) {
         if (!prevState.transition.round) {
           void animateRoundTransition(
             dispatch,
             prevState,
             state,
-            prevState.game.round === 0
+            prevState.game.phase === GamePhase.NOT_STARTED || prevState.game.phase === GamePhase.ENDED
           );
         }
       } else {


### PR DESCRIPTION
this PR fixes the fact that 
 - the story-quizz game teleport user which are not playing
 - teleport and animation are slow when starting the game