### PR TITLE
✨ mock sdk

### DIFF
--- a/elements/reigns/sdk.js
+++ b/elements/reigns/sdk.js
@@ -1,0 +1,79 @@
+// fake sdk, used for local development
+window.addEventListener("load", (event) => {
+  console.log("load");
+  window.fresco._listeners.forEach((listener) => listener());
+});
+
+let onStateChangedHandler;
+
+window.fresco.onStateChanged = (callback) => {
+  onStateChangedHandler = callback;
+};
+
+const realtimeData = JSON.parse(localStorage.getItem("local-realtime")) || {};
+function update() {
+  localStorage.setItem("local-realtime", JSON.stringify(realtimeData));
+  setTimeout(() => {
+    onStateChangedHandler && onStateChangedHandler();
+  }, 0);
+}
+
+let globalHandlers = {};
+window.fresco.initialize = (state, config) => {
+  window.fresco.element = {
+    state,
+  };
+  window.fresco.localParticipant = {
+    id: "local-participant",
+    name: "Local Participant",
+    permission: {
+      canEdit: true,
+    },
+  };
+  window.fresco.isMockSdk = true;
+  window.fresco.remoteParticipants = [];
+  window.fresco.triggerEvent = () => {};
+  window.fresco.subscribeToGlobalEvent = (eventName, handler) => {
+    if (!globalHandlers[eventName]) {
+      globalHandlers[eventName] = [handler];
+    } else {
+      globalHandlers[eventName].push(handler);
+    }
+
+    return () => {
+      globalHandlers[eventName] = globalHandlers[eventName].filter(
+        (h) => h !== handler
+      );
+      if (globalHandlers[eventName].length === 0) {
+        delete globalHandlers[eventName];
+      }
+    };
+  };
+  update();
+};
+
+window.fresco.storage = {
+  realtime: {
+    set: (tableName, key, value) => {
+      if (!key || !tableName) {
+        return;
+      }
+
+      if (!realtimeData[tableName]) {
+        realtimeData[tableName] = {};
+      }
+
+      realtimeData[tableName][key] = value;
+      update();
+    },
+    get: (tableName, key) => {
+      return realtimeData[tableName] && realtimeData[tableName][key];
+    },
+    all: (tableName) => realtimeData[tableName] ?? {},
+    clear: (tableName) => {
+      realtimeData[tableName] = {};
+      update();
+    },
+    data: realtimeData,
+  },
+};

--- a/elements/reigns/src/AnswerArea.tsx
+++ b/elements/reigns/src/AnswerArea.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { useSelector } from "react-redux";
 import { useRoundedRectangleProgress } from "./features/voting/useRoundedRectangleProgress";
 import { AppState } from "./store";
+import { mockSdkVote } from "./mockSdkVote";
 
 type Props = {
   text: string;
@@ -55,7 +56,10 @@ export const AnswerArea = ({
           )}
         </div>
       </div>
-      <div className={`answer__zone answer--${answer}`}></div>
+      <div
+        className={`answer__zone answer--${answer}`}
+        onClick={() => mockSdkVote(answer)}
+      ></div>
     </div>
   );
 };

--- a/elements/reigns/src/fresco.d.ts
+++ b/elements/reigns/src/fresco.d.ts
@@ -77,6 +77,7 @@ interface IFrescoSdk {
     identityId: string;
     isInsideElement: boolean;
   };
+  isMockSdk: undefined | boolean;
   remoteParticipants: Participant[];
   /*
    * Table array storage is expected to be persisted for the lifetime of an element unless cleared.

--- a/elements/reigns/src/mockSdkVote.tsx
+++ b/elements/reigns/src/mockSdkVote.tsx
@@ -1,0 +1,18 @@
+import { persistParticipantVote } from "./features/voting/persistence";
+import { PARTICIPANT_INSIDE_TABLE } from "./features/voting/useOnFrescoStateUpdate";
+import { getSdk } from "./sdk";
+
+export const mockSdkVote = (answer: "yes" | "no") => {
+  const sdk = getSdk();
+  if (!sdk.isMockSdk) return;
+
+  sdk.storage.realtime.set(
+    PARTICIPANT_INSIDE_TABLE,
+    sdk.localParticipant.id,
+    true
+  );
+  persistParticipantVote(
+    sdk.localParticipant.id,
+    answer === "yes" ? "Yes" : "No"
+  );
+};


### PR DESCRIPTION
This is a follow up from https://github.com/fres-co/fresco-community/pull/94 which implements some items that `elements/reigns` needs. There's a couple of issues with it, but it mostly works.

features:

* loads game
* local player can start game
* local player can play game
* all realtime data cached in `localStorage`, so supports refresh
* appears to support HMD better than embedded version

issues:

* had to add game-specific support (see mockSdkVote)
* transitions supported poorly, progress animation is still occurring _after_ round completion