### PR TITLE
Feature/fres 1503 custom death actions

### DIFF
--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -18,7 +18,10 @@ export const Game = () => {
     useSelector((state: AppState) => state.voting.countdown)
   );
   const phase = useSelector((state: AppState) => state.game.phase);
-  const isGameWon =  useSelector((state: AppState) => state.game.flags[VICTORY_FLAG_NAME] === VICTORY_FLAG_VALUE);
+  const isGameWon = useSelector(
+    (state: AppState) =>
+      state.game.flags[VICTORY_FLAG_NAME] === VICTORY_FLAG_VALUE
+  );
 
   const round = useSelector((state: AppState) => state.game.round);
   const selectedCard = useSelector(
@@ -49,10 +52,21 @@ export const Game = () => {
 
   useEffect(() => {
     if (phase === GamePhase.ENDED) {
-      const audio = new Audio("error.mp3");
-      audio.play();
+      if (isGameWon) {
+        fresco.triggerEvent({
+          eventName: "custom.reigns.phase.end.victory",
+        });
+      } else {
+        fresco.triggerEvent({
+          eventName: "custom.reigns.phase.end.death",
+        });
+      }
+    } else {
+      fresco.triggerEvent({
+        eventName: `custom.reigns.phase.${phase}`,
+      });
     }
-  }, [phase]);
+  }, [phase, isGameWon]);
 
   const doRestartGame = () => {
     if (isHost) {
@@ -68,7 +82,11 @@ export const Game = () => {
           <div className="round">
             {gameDefinition?.roundName} {round}
           </div>
-          <div className="end__message">{isGameWon ? gameDefinition?.victoryMessage : gameDefinition?.deathMessage}</div>
+          <div className="end__message">
+            {isGameWon
+              ? gameDefinition?.victoryMessage
+              : gameDefinition?.deathMessage}
+          </div>
           {isHost && <button onClick={doRestartGame}>Play again</button>}
         </div>
       </div>

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -11,6 +11,7 @@ import { Game as GamePersistence } from "./features/game/Game";
 import { getIsHost } from "./features/host/persistence";
 import { AnswerArea } from "./AnswerArea";
 import { Countdown } from "./Countdown";
+import { getSdk } from "./sdk";
 
 export const Game = () => {
   const currentHost = useSelector((state: AppState) => state.host.currentHost);
@@ -51,18 +52,19 @@ export const Game = () => {
   useCollateVotes();
 
   useEffect(() => {
+    const sdk = getSdk();
     if (phase === GamePhase.ENDED) {
       if (isGameWon) {
-        fresco.triggerEvent({
+        sdk.triggerEvent({
           eventName: "custom.reigns.phase.end.victory",
         });
       } else {
-        fresco.triggerEvent({
+        sdk.triggerEvent({
           eventName: "custom.reigns.phase.end.death",
         });
       }
     } else {
-      fresco.triggerEvent({
+      sdk.triggerEvent({
         eventName: `custom.reigns.phase.${phase}`,
       });
     }

--- a/elements/reigns/src/features/game/Game.test.ts
+++ b/elements/reigns/src/features/game/Game.test.ts
@@ -19,28 +19,6 @@ describe("Game", () => {
     mockSdk();
   });
   describe("game over", () => {
-    it("should clear participant votes", () => {
-      persistGameVote({
-        answer: "No",
-        countdown: 3,
-      });
-      persistParticipantVote(getSdk().localParticipant.id, "Yes");
-
-      const result = new Game()
-        .answerNo(
-          createGameState(undefined, {
-            stats: [10],
-            selectedCard: createCard({ no_stat1: -20 }),
-          })
-        )
-        .retrieve();
-
-      const answer = getGameVote();
-      expect(answer).toEqual({});
-
-      expect(result.phase).toBe(GamePhase.ENDED);
-      expect(getSdk().storage.realtime.all(PARTICIPANT_VOTE_TABLE)).toEqual({});
-    });
     describe("startGame", () => {
       it("should select a card and set round to 1", () => {
         const result = new Game()

--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -23,9 +23,6 @@ export class Game {
 
   private persist(state: PersistedGameState) {
     getSdk().storage.realtime.set(GAME_TABLE, GAME_STATE_KEY, state);
-    if (state.phase === GamePhase.ENDED) {
-      // this.clearVotes(); // too early to do that
-    }
   }
 
   private clearVotes() {
@@ -40,7 +37,7 @@ export class Game {
       selectedCard: null,
       round: 0,
       flags: {},
-      stats: []
+      stats: [],
     });
     this.clearVotes();
   }

--- a/elements/reigns/src/features/game/Game.ts
+++ b/elements/reigns/src/features/game/Game.ts
@@ -24,7 +24,7 @@ export class Game {
   private persist(state: PersistedGameState) {
     getSdk().storage.realtime.set(GAME_TABLE, GAME_STATE_KEY, state);
     if (state.phase === GamePhase.ENDED) {
-      this.clearVotes();
+      // this.clearVotes(); // too early to do that
     }
   }
 

--- a/inventory/index.json
+++ b/inventory/index.json
@@ -208,6 +208,34 @@
           }
         },
         {
+          "id": "udwa4u4_t-srbrd22fhim",
+          "isLocked": false,
+          "zIndex": 5,
+          "layer": 0,
+          "renderer": "Sound",
+          "transform": {
+            "position": {
+              "x": 73,
+              "y": 584
+            },
+            "size": {
+              "x": 30,
+              "y": 30
+            },
+            "rotation": 0
+          },
+          "appearance": {
+            "EVENTS": "",
+            "TEXT": "vote-death.mp3",
+            "TEXT_DISABLED": true,
+            "RADIUS": "6000",
+            "SOURCE": "https://fres-co.github.io/fresco-community/elements/reigns/public/error.mp3",
+            "VOLUME": 0,
+            "LOOP": false,
+            "SPATIALIZED": false
+          }
+        },
+        {
           "id": "aoy7acumnzsdwbfodo7uh",
           "isLocked": false,
           "zIndex": 6,
@@ -384,7 +412,7 @@
             "rotation": 0
           },
           "appearance": {
-            "EVENTS": "[{\"event\":\"custom.reigns.voteAdded\",\"scope\":\"global\",\"actions\":[{\"id\":\"hy5koxuw_axrspmodcjgy\",\"type\":\"PLAY_SOUND\",\"payload\":{\"soundName\":\"vote-added.mp3\",\"volume\":\"0.3\"}}]},{\"event\":\"custom.reigns.voteRemoved\",\"scope\":\"global\",\"actions\":[{\"id\":\"htyp5uqr0cyxe-y671wbq\",\"type\":\"PLAY_SOUND\",\"payload\":{\"soundName\":\"vote-removed.mp3\",\"volume\":\"0.5\"}}]}]",
+            "EVENTS": "[{\"event\":\"custom.reigns.voteAdded\",\"scope\":\"global\",\"actions\":[{\"id\":\"ky5koxuw_axrspmodcjgy\",\"type\":\"PLAY_SOUND\",\"payload\":{\"soundName\":\"vote-added.mp3\",\"volume\":\"0.3\"}}]},{\"event\":\"custom.reigns.voteRemoved\",\"scope\":\"global\",\"actions\":[{\"id\":\"htyp5uqr0cyxe-y671wbq\",\"type\":\"PLAY_SOUND\",\"payload\":{\"soundName\":\"vote-removed.mp3\",\"volume\":\"0.5\"}}]},{\"event\":\"custom.reigns.phase.end.death\",\"scope\":\"global\",\"actions\":[{\"id\":\"ky5koxuw_axrspmodcjgy\",\"type\":\"PLAY_SOUND\",\"payload\":{\"soundName\":\"vote-death.mp3\",\"volume\":\"0.3\"}}]}]",
             "NAME": "story-quizz",
             "TEXT_BEHAVIOUR": 2,
             "STATE": {
@@ -558,6 +586,7 @@
             "eolco0cygtbt4u9lcygk2",
             "lwwhmffngu0gpnurw8bg5",
             "udwa4u4_t-srbrd22fhin",
+            "udwa4u4_t-srbrd22fhim",
             "hjj6qlbu2kkzszvsuecv_"
           ],
           "transform": {


### PR DESCRIPTION
This PR implements the fact that fresco space can react to death or victory events, instead of hard coding the death sound inside the extension.

@staff0rd the unit test are breaking because of https://github.com/fres-co/fresco-community/pull/110/files#diff-c898c7c1fe7a462256fdb8dbaf83cb70ec62c733d0ee503d2f54b82de5093ec8R27
Without it, the votes are reset too early, and the removeVote events will then be triggered.
I'll let you decide if we can safely remove that test, 