### PR TITLE
Feature/fres 1288 death screen with stats

### DIFF
--- a/elements/reigns/public/games/demo.json
+++ b/elements/reigns/public/games/demo.json
@@ -8,7 +8,7 @@
       "name": "Profit",
       "icon": "noun-coins-1123601.svg",
       "value": 50,
-      "deathMessage": "Your company goes bankruptcy."
+      "deathMessage": "Your company goes into bankruptcy"
     },
     {
       "name": "Customer satisfaction",
@@ -26,7 +26,7 @@
       "name": "Team well-being",
       "icon": "noun-team-4854330.svg",
       "value": 50,
-      "deathMessage": "The CEO has not other choice but to replace you."
+      "deathMessage": "The CEO has no other choice but to replace you"
     }
   ],
   "assetsUrl": "games",

--- a/elements/reigns/public/games/demo.json
+++ b/elements/reigns/public/games/demo.json
@@ -7,22 +7,26 @@
     {
       "name": "Profit",
       "icon": "noun-coins-1123601.svg",
-      "value": 50
+      "value": 50,
+      "deathMessage": "Your company goes bankruptcy."
     },
     {
       "name": "Customer satisfaction",
       "icon": "noun-crowd-2383331.svg",
-      "value": 50
+      "value": 50,
+      "deathMessage": "No customers, no money"
     },
     {
       "name": "Security",
       "icon": "noun-shield-4865890.svg",
-      "value": 50
+      "value": 50,
+      "deathMessage": "You have been fired. Data security was under your umbrella"
     },
     {
       "name": "Team well-being",
       "icon": "noun-team-4854330.svg",
-      "value": 50
+      "value": 50,
+      "deathMessage": "The CEO has not other choice but to replace you."
     }
   ],
   "assetsUrl": "games",

--- a/elements/reigns/src/App.tsx
+++ b/elements/reigns/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
 
   if (!sdkLoaded || loading === Loading.InProgress) {
     return (
-      <div className="game-half first-half">
+      <div className="game-half first-half game--loading">
         <div className="end">Loading...</div>
       </div>
     );
@@ -35,7 +35,7 @@ export default function App() {
 
   if (loading === Loading.Error) {
     return (
-      <div className="game-half first-half">
+      <div className="game-half first-half game--error">
         <div className="end">ERROR :(</div>
       </div>
     );

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -81,13 +81,11 @@ export const Game = () => {
 
   if (phase === GamePhase.NOT_STARTED) {
     return (
-      <div className="game-half first-half">
-        <div className="end">
-          <div className="end__message">{gameDefinition?.gameName}</div>
-          {isHost && <button onClick={doRestartGame}>Start game</button>}
-          {!isHost && <div>Waiting for host to start...</div>}
-        </div>
-      </div>
+      <NotStartScreen
+        gameDefinition={gameDefinition}
+        isHost={isHost}
+        doRestartGame={doRestartGame}
+      />
     );
   }
 
@@ -168,6 +166,32 @@ const getEndMessage = (
 
   return gameDefinition.deathMessage;
 };
+function NotStartScreen({
+  gameDefinition,
+  isHost,
+  doRestartGame,
+}: {
+  gameDefinition: GameDefinition | null;
+  isHost: string | boolean | undefined;
+  doRestartGame: () => void;
+}) {
+  const messageRef = useTextFit(gameDefinition?.gameName);
+
+  return (
+    <div className="game-half first-half">
+      <div className="end">
+        <div className="end__message" ref={messageRef} />
+        {isHost && (
+          <button className="end__restart_button" onClick={doRestartGame}>
+            Start game
+          </button>
+        )}
+        {!isHost && <div>Waiting for host to start...</div>}
+      </div>
+    </div>
+  );
+}
+
 function EndScreen({
   gameDefinition,
   currentStats,

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -77,23 +77,6 @@ export const Game = () => {
     }
   };
 
-  if (phase === GamePhase.ENDED) {
-    return (
-      <div className="game-half first-half">
-        <div className="end">
-          <div className="round">
-            {gameDefinition?.roundName} {round}
-          </div>
-          <div className="end__message">
-            {isGameWon
-              ? gameDefinition?.victoryMessage
-              : gameDefinition?.deathMessage}
-          </div>
-          {isHost && <button onClick={doRestartGame}>Play again</button>}
-        </div>
-      </div>
-    );
-  }
 
   if (phase === GamePhase.NOT_STARTED) {
     return (
@@ -107,7 +90,34 @@ export const Game = () => {
     );
   }
 
-  if (!selectedCard || !gameDefinition) {
+  if (!gameDefinition) {
+    return null;
+  }
+
+  if (phase === GamePhase.ENDED) {
+    return (
+      <div className="game-half first-half">
+         <Header
+          definition={gameDefinition}
+          stats={currentStats}
+          round={round}
+        />
+
+        <div className="end">
+         
+          <div className="end__message">
+            {isGameWon
+              ? gameDefinition?.victoryMessage
+              : gameDefinition?.deathMessage}
+          </div>
+          {isHost && <button onClick={doRestartGame}>Play again</button>}
+        </div>
+      </div>
+    );
+  }
+
+
+  if (!selectedCard) {
     return null;
   }
 

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -13,6 +13,7 @@ import { AnswerArea } from "./AnswerArea";
 import { Countdown } from "./Countdown";
 import { getSdk } from "./sdk";
 import { GameDefinition } from "./features/game/types";
+import { useTextFit } from "./useTextFit";
 
 export const Game = () => {
   const currentHost = useSelector((state: AppState) => state.host.currentHost);
@@ -95,20 +96,15 @@ export const Game = () => {
   }
 
   if (phase === GamePhase.ENDED) {
-    const endMessage = getEndMessage(gameDefinition, currentStats, isGameWon);
     return (
-      <div className="game-half first-half">
-        <Header
-          definition={gameDefinition}
-          stats={currentStats}
-          round={round}
-        />
-
-        <div className="end">
-          <div className="end__message">{endMessage}</div>
-          {isHost && <button onClick={doRestartGame}>Play again</button>}
-        </div>
-      </div>
+      <EndScreen
+        gameDefinition={gameDefinition}
+        currentStats={currentStats}
+        isGameWon={isGameWon}
+        round={round}
+        isHost={isHost}
+        doRestartGame={doRestartGame}
+      />
     );
   }
 
@@ -162,8 +158,6 @@ const getEndMessage = (
     return gameDefinition.victoryMessage;
   }
 
-  debugger;
-
   const emptyIndex = statsValues.findIndex((statValue) => statValue <= 0);
   if (emptyIndex > -1) {
     return (
@@ -174,3 +168,37 @@ const getEndMessage = (
 
   return gameDefinition.deathMessage;
 };
+function EndScreen({
+  gameDefinition,
+  currentStats,
+  isGameWon,
+  round,
+  isHost,
+  doRestartGame,
+}: {
+  gameDefinition: GameDefinition;
+  currentStats: number[];
+  isGameWon: boolean;
+  round: number;
+  isHost: string | boolean | undefined;
+  doRestartGame: () => void;
+}) {
+  const endMessage = getEndMessage(gameDefinition, currentStats, isGameWon);
+
+  const messageRef = useTextFit(endMessage);
+
+  return (
+    <div className="game-half first-half">
+      <Header definition={gameDefinition} stats={currentStats} round={round} />
+
+      <div className="end">
+        <div className="end__message" ref={messageRef} />
+        {isHost && (
+          <button onClick={doRestartGame} className="end__restart_button">
+            Play again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -94,6 +94,7 @@ export const Game = () => {
   if (phase === GamePhase.ENDED) {
     return (
       <EndedScreen
+        key="screen"
         gameDefinition={gameDefinition}
         currentStats={currentStats}
         isGameWon={isGameWon}
@@ -110,6 +111,7 @@ export const Game = () => {
 
   return (
     <StartedScreen
+      key="screen"
       gameDefinition={gameDefinition}
       currentStats={currentStats}
       round={round}

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect } from "react";
-import { Header } from "./Header";
-import { Question } from "./Question";
 import { useSelector, useStore } from "react-redux";
 import { GamePhase, VICTORY_FLAG_NAME, VICTORY_FLAG_VALUE } from "./constants";
 import { usePersistIsMounted } from "./features/host/usePersistIsMounted";
@@ -9,11 +7,11 @@ import { useVoteListener } from "./features/voting/useVoteListener";
 import { useCollateVotes } from "./features/voting/useCollateVotes";
 import { Game as GamePersistence } from "./features/game/Game";
 import { getIsHost } from "./features/host/persistence";
-import { AnswerArea } from "./AnswerArea";
 import { Countdown } from "./Countdown";
 import { getSdk } from "./sdk";
-import { GameDefinition } from "./features/game/types";
-import { useTextFit } from "./useTextFit";
+import { EndedScreen } from "./screens/EndedScreen/EndedScreen";
+import { NotStartedScreen } from "./screens/NotStartedScreen";
+import { StartedScreen } from "./screens/StartedScreen";
 
 export const Game = () => {
   const currentHost = useSelector((state: AppState) => state.host.currentHost);
@@ -81,7 +79,7 @@ export const Game = () => {
 
   if (phase === GamePhase.NOT_STARTED) {
     return (
-      <NotStartScreen
+      <NotStartedScreen
         gameDefinition={gameDefinition}
         isHost={isHost}
         doRestartGame={doRestartGame}
@@ -95,7 +93,7 @@ export const Game = () => {
 
   if (phase === GamePhase.ENDED) {
     return (
-      <EndScreen
+      <EndedScreen
         gameDefinition={gameDefinition}
         currentStats={currentStats}
         isGameWon={isGameWon}
@@ -111,118 +109,17 @@ export const Game = () => {
   }
 
   return (
-    <>
-      <div className="game-half first-half" onClick={doRestartGame}>
-        <Header
-          definition={gameDefinition}
-          stats={currentStats}
-          round={round}
-        />
-        <Question card={selectedCard} />
-      </div>
-      <div className="game-half answers">
-        <AnswerArea
-          text={selectedCard.answer_no || "No"}
-          answer="no"
-          progress={noProgress}
-          color="#e200a4"
-          votesMissing={noVotesMissing}
-        />
-        <div className="answer answer--neutral">
-          {countdown.isVoting && (
-            <div className="countdown" data-testid="countdown">
-              <>{countdown.value}...</>
-            </div>
-          )}
-        </div>
-        <AnswerArea
-          text={selectedCard.answer_yes || "Yes"}
-          answer="yes"
-          progress={yesProgress}
-          color="#9e32d6"
-          votesMissing={yesVotesMissing}
-        />
-      </div>
-    </>
+    <StartedScreen
+      gameDefinition={gameDefinition}
+      currentStats={currentStats}
+      round={round}
+      selectedCard={selectedCard}
+      countdown={countdown}
+      doRestartGame={doRestartGame}
+      noProgress={noProgress}
+      yesProgress={yesProgress}
+      noVotesMissing={noVotesMissing}
+      yesVotesMissing={yesVotesMissing}
+    />
   );
 };
-
-const getEndMessage = (
-  gameDefinition: GameDefinition,
-  statsValues: number[],
-  isGameWon: boolean
-) => {
-  if (isGameWon) {
-    return gameDefinition.victoryMessage;
-  }
-
-  const emptyIndex = statsValues.findIndex((statValue) => statValue <= 0);
-  if (emptyIndex > -1) {
-    return (
-      gameDefinition.stats[emptyIndex].deathMessage ??
-      gameDefinition.deathMessage
-    );
-  }
-
-  return gameDefinition.deathMessage;
-};
-function NotStartScreen({
-  gameDefinition,
-  isHost,
-  doRestartGame,
-}: {
-  gameDefinition: GameDefinition | null;
-  isHost: string | boolean | undefined;
-  doRestartGame: () => void;
-}) {
-  const messageRef = useTextFit(gameDefinition?.gameName);
-
-  return (
-    <div className="game-half first-half">
-      <div className="end">
-        <div className="end__message" ref={messageRef} />
-        {isHost && (
-          <button className="end__restart_button" onClick={doRestartGame}>
-            Start game
-          </button>
-        )}
-        {!isHost && <div>Waiting for host to start...</div>}
-      </div>
-    </div>
-  );
-}
-
-function EndScreen({
-  gameDefinition,
-  currentStats,
-  isGameWon,
-  round,
-  isHost,
-  doRestartGame,
-}: {
-  gameDefinition: GameDefinition;
-  currentStats: number[];
-  isGameWon: boolean;
-  round: number;
-  isHost: string | boolean | undefined;
-  doRestartGame: () => void;
-}) {
-  const endMessage = getEndMessage(gameDefinition, currentStats, isGameWon);
-
-  const messageRef = useTextFit(endMessage);
-
-  return (
-    <div className="game-half first-half">
-      <Header definition={gameDefinition} stats={currentStats} round={round} />
-
-      <div className="end">
-        <div className="end__message" ref={messageRef} />
-        {isHost && (
-          <button onClick={doRestartGame} className="end__restart_button">
-            Play again
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}

--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -12,6 +12,7 @@ import { getIsHost } from "./features/host/persistence";
 import { AnswerArea } from "./AnswerArea";
 import { Countdown } from "./Countdown";
 import { getSdk } from "./sdk";
+import { GameDefinition } from "./features/game/types";
 
 export const Game = () => {
   const currentHost = useSelector((state: AppState) => state.host.currentHost);
@@ -77,7 +78,6 @@ export const Game = () => {
     }
   };
 
-
   if (phase === GamePhase.NOT_STARTED) {
     return (
       <div className="game-half first-half">
@@ -95,27 +95,22 @@ export const Game = () => {
   }
 
   if (phase === GamePhase.ENDED) {
+    const endMessage = getEndMessage(gameDefinition, currentStats, isGameWon);
     return (
       <div className="game-half first-half">
-         <Header
+        <Header
           definition={gameDefinition}
           stats={currentStats}
           round={round}
         />
 
         <div className="end">
-         
-          <div className="end__message">
-            {isGameWon
-              ? gameDefinition?.victoryMessage
-              : gameDefinition?.deathMessage}
-          </div>
+          <div className="end__message">{endMessage}</div>
           {isHost && <button onClick={doRestartGame}>Play again</button>}
         </div>
       </div>
     );
   }
-
 
   if (!selectedCard) {
     return null;
@@ -156,4 +151,26 @@ export const Game = () => {
       </div>
     </>
   );
+};
+
+const getEndMessage = (
+  gameDefinition: GameDefinition,
+  statsValues: number[],
+  isGameWon: boolean
+) => {
+  if (isGameWon) {
+    return gameDefinition.victoryMessage;
+  }
+
+  debugger;
+
+  const emptyIndex = statsValues.findIndex((statValue) => statValue <= 0);
+  if (emptyIndex > -1) {
+    return (
+      gameDefinition.stats[emptyIndex].deathMessage ??
+      gameDefinition.deathMessage
+    );
+  }
+
+  return gameDefinition.deathMessage;
 };

--- a/elements/reigns/src/Meter.tsx
+++ b/elements/reigns/src/Meter.tsx
@@ -41,14 +41,20 @@ export const Meter = ({
   }, [percent]);
 
   return (
-    <div className="meter">
+    <div className={"meter"}>
       <div className="meter__label">
         <img src={`${assetsUrl}/${src}`} />
         <div className="meter__name" title={name}>
           {name}
         </div>
       </div>
-      <div className={clsx("meter__progress", currentAnimation)}>
+      <div
+        className={clsx(
+          "meter__progress",
+          currentAnimation,
+          percent <= 0 && "red-glow"
+        )}
+      >
         <div className="meter__percent" style={{ width: percent + "%" }} />
       </div>
       <MeterArrow

--- a/elements/reigns/src/features/game/parseGameFromCsv.test.ts
+++ b/elements/reigns/src/features/game/parseGameFromCsv.test.ts
@@ -1,12 +1,14 @@
 import { parseGameFromCsv } from "./parseGameFromCsv";
 import { GameDefinition } from "./types";
 
-const getData = ({ main: { victoryRoundThreshold = `10` } = {}} = {}) => `SECTION,,,,,,,,,,,,,,,,,,,
+const getData = ({
+  main: { victoryRoundThreshold = `10` } = {},
+} = {}) => `SECTION,,,,,,,,,,,,,,,,,,,
 main,gameName,deathMessage,victoryMessage,victoryRoundThreshold,roundName,assetsUrl,,,,,,,,,,,,,,,
 ,A month in the life of a data officer,You have been fired!,You won!,${victoryRoundThreshold},Day,games,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,
-stats,name,icon,value,,,,,,,,,,,,,,,,
-,Profit,noun-coins-1123601.svg,50,,,,,,,,,,,,,,,,
+stats,name,icon,value,deathMessage,,,,,,,,,,,,,,,
+,Profit,noun-coins-1123601.svg,50,Need more money,,,,,,,,,,,,,,,
 ,Customer satisfaction,noun-crowd-2383331.svg,37,,,,,,,,,,,,,,,,
 ,Security,noun-shield-4865890.svg,5,,,,,,,,,,,,,,,,
 ,Team well-being,noun-team-4854330.svg,78,,,,,,,,,,,,,,,,
@@ -45,6 +47,7 @@ describe("parseGameFromCsv", () => {
     expect(stats[0].name).toBe("Profit");
     expect(stats[0].icon).toBe("noun-coins-1123601.svg");
     expect(stats[0].value).toBe(50);
+    expect(stats[0].deathMessage).toBe("Need more money");
 
     expect(stats[1].name).toBe("Customer satisfaction");
     expect(stats[1].icon).toBe("noun-crowd-2383331.svg");
@@ -60,15 +63,19 @@ describe("parseGameFromCsv", () => {
   });
 
   it("should parse main section from string", () => {
-    const { gameName, deathMessage, victoryMessage, victoryRoundThreshold, roundName, assetsUrl } = parseGameFromCsv(
-      getData()
-    ) as GameDefinition;
+    const {
+      gameName,
+      deathMessage,
+      victoryMessage,
+      victoryRoundThreshold,
+      roundName,
+      assetsUrl,
+    } = parseGameFromCsv(getData()) as GameDefinition;
 
     expect(gameName).toBe("A month in the life of a data officer");
     expect(deathMessage).toBe("You have been fired!");
     expect(victoryMessage).toBe("You won!");
     expect(victoryRoundThreshold).toBe(10);
-
 
     expect(roundName).toBe("Day");
     expect(assetsUrl).toBe("games");

--- a/elements/reigns/src/features/game/types.ts
+++ b/elements/reigns/src/features/game/types.ts
@@ -4,6 +4,7 @@ export type Stat = {
   value: number;
   icon: string;
   name: string;
+  deathMessage?: string;
 };
 
 export type CardFlag = {

--- a/elements/reigns/src/screens/EndedScreen/EndedScreen.tsx
+++ b/elements/reigns/src/screens/EndedScreen/EndedScreen.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Header } from "../../Header";
+import { GameDefinition } from "../../features/game/types";
+import { useTextFit } from "../../useTextFit";
+import { getEndMessage } from "./utils";
+
+export function EndedScreen({
+  gameDefinition,
+  currentStats,
+  isGameWon,
+  round,
+  isHost,
+  doRestartGame,
+}: {
+  gameDefinition: GameDefinition;
+  currentStats: number[];
+  isGameWon: boolean;
+  round: number;
+  isHost: string | boolean | undefined;
+  doRestartGame: () => void;
+}) {
+  const endMessage = getEndMessage(gameDefinition, currentStats, isGameWon);
+
+  const messageRef = useTextFit(endMessage);
+
+  return (
+    <div className="game-half first-half">
+      <Header definition={gameDefinition} stats={currentStats} round={round} />
+
+      <div className="end">
+        <div className="end__message" ref={messageRef} />
+        {isHost && (
+          <button onClick={doRestartGame} className="end__restart_button">
+            Play again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/elements/reigns/src/screens/EndedScreen/EndedScreen.tsx
+++ b/elements/reigns/src/screens/EndedScreen/EndedScreen.tsx
@@ -24,7 +24,7 @@ export function EndedScreen({
   const messageRef = useTextFit(endMessage);
 
   return (
-    <div className="game-half first-half">
+    <div className="game-half first-half game--ended">
       <Header definition={gameDefinition} stats={currentStats} round={round} />
 
       <div className="end">

--- a/elements/reigns/src/screens/EndedScreen/utils.ts
+++ b/elements/reigns/src/screens/EndedScreen/utils.ts
@@ -1,0 +1,21 @@
+import { GameDefinition } from "../../features/game/types";
+
+export const getEndMessage = (
+  gameDefinition: GameDefinition,
+  statsValues: number[],
+  isGameWon: boolean
+) => {
+  if (isGameWon) {
+    return gameDefinition.victoryMessage;
+  }
+
+  const emptyIndex = statsValues.findIndex((statValue) => statValue <= 0);
+  if (emptyIndex > -1) {
+    return (
+      gameDefinition.stats[emptyIndex].deathMessage ??
+      gameDefinition.deathMessage
+    );
+  }
+
+  return gameDefinition.deathMessage;
+};

--- a/elements/reigns/src/screens/NotStartedScreen.tsx
+++ b/elements/reigns/src/screens/NotStartedScreen.tsx
@@ -14,7 +14,7 @@ export function NotStartedScreen({
   const messageRef = useTextFit(gameDefinition?.gameName);
 
   return (
-    <div className="game-half first-half">
+    <div className="game-half first-half game--not-started">
       <div className="end">
         <div className="end__message" ref={messageRef} />
         {isHost && (

--- a/elements/reigns/src/screens/NotStartedScreen.tsx
+++ b/elements/reigns/src/screens/NotStartedScreen.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { GameDefinition } from "../features/game/types";
+import { useTextFit } from "../useTextFit";
+
+export function NotStartedScreen({
+  gameDefinition,
+  isHost,
+  doRestartGame,
+}: {
+  gameDefinition: GameDefinition | null;
+  isHost: string | boolean | undefined;
+  doRestartGame: () => void;
+}) {
+  const messageRef = useTextFit(gameDefinition?.gameName);
+
+  return (
+    <div className="game-half first-half">
+      <div className="end">
+        <div className="end__message" ref={messageRef} />
+        {isHost && (
+          <button className="end__restart_button" onClick={doRestartGame}>
+            Start game
+          </button>
+        )}
+        {!isHost && <div>Waiting for host to start...</div>}
+      </div>
+    </div>
+  );
+}

--- a/elements/reigns/src/screens/StartedScreen.tsx
+++ b/elements/reigns/src/screens/StartedScreen.tsx
@@ -29,7 +29,7 @@ export const StartedScreen = ({
   doRestartGame: () => void;
 }) => (
   <>
-    <div className="game-half first-half" onClick={doRestartGame}>
+    <div className="game-half first-half game--started" onClick={doRestartGame}>
       <Header definition={gameDefinition} stats={currentStats} round={round} />
       <Question card={selectedCard} />
     </div>

--- a/elements/reigns/src/screens/StartedScreen.tsx
+++ b/elements/reigns/src/screens/StartedScreen.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Header } from "../Header";
+import { Question } from "../Question";
+import { AnswerArea } from "../AnswerArea";
+import { Countdown } from "../Countdown";
+import { Card, GameDefinition } from "../features/game/types";
+
+export const StartedScreen = ({
+  gameDefinition,
+  currentStats,
+  round,
+  selectedCard,
+  noProgress,
+  yesProgress,
+  noVotesMissing,
+  yesVotesMissing,
+  countdown,
+  doRestartGame,
+}: {
+  gameDefinition: GameDefinition;
+  currentStats: number[];
+  round: number;
+  selectedCard: Card;
+  noProgress: number;
+  yesProgress: number;
+  noVotesMissing: number | null;
+  yesVotesMissing: number | null;
+  countdown: Countdown;
+  doRestartGame: () => void;
+}) => (
+  <>
+    <div className="game-half first-half" onClick={doRestartGame}>
+      <Header definition={gameDefinition} stats={currentStats} round={round} />
+      <Question card={selectedCard} />
+    </div>
+    <div className="game-half answers">
+      <AnswerArea
+        text={selectedCard.answer_no || "No"}
+        answer="no"
+        progress={noProgress}
+        color="#e200a4"
+        votesMissing={noVotesMissing}
+      />
+      <div className="answer answer--neutral">
+        {countdown.isVoting && (
+          <div className="countdown" data-testid="countdown">
+            <>{countdown.value}...</>
+          </div>
+        )}
+      </div>
+      <AnswerArea
+        text={selectedCard.answer_yes || "Yes"}
+        answer="yes"
+        progress={yesProgress}
+        color="#9e32d6"
+        votesMissing={yesVotesMissing}
+      />
+    </div>
+  </>
+);

--- a/elements/reigns/src/screens/card,id,bearer,conditions,cooldown,weigh
+++ b/elements/reigns/src/screens/card,id,bearer,conditions,cooldown,weigh
@@ -1,0 +1,3 @@
+card,id,bearer,conditions,cooldown,weight,override_yes,answer_yes,yes_stat1,yes_stat2,yes_stat3,yes_stat4,yes_custom,answer_no,no_stat1,no_stat2,no_stat3,no_stat4,no_custom
+cooldown-3,card-1,entrepreneur,,3,1,,,0,0,0,0,,,0,0,0,,
+cooldown-1,card-2,customer-support,,,1,,,0,-100,0,0,,,0,0,0,,

--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -79,13 +79,13 @@ button {
   border-radius: 5px;
 }
 
-.meter__progress--grow .meter__percent,
-.meter__progress--grow--big .meter__percent {
+.game--started .meter__progress--grow .meter__percent,
+.game--started .meter__progress--grow--big .meter__percent {
   background-color: green;
 }
 
-.meter__progress--shrink .meter__percent,
-.meter__progress--shrink--big .meter__percent {
+.game--started .meter__progress--shrink .meter__percent,
+.game--started .meter__progress--shrink--big .meter__percent {
   background-color: red;
 }
 
@@ -99,15 +99,15 @@ button {
   color: var(--color-primary);
 }
 
-.meter__progress--shrink.meter__arrow,
-.meter__progress--shrink--big.meter__arrow {
+.game--started .meter__progress--shrink.meter__arrow,
+.game--started .meter__progress--shrink--big.meter__arrow {
   transition: opacity var(--stats-color-transition-duration) ease, color 0s;
   color: red;
   opacity: 1;
 }
 
-.meter__progress--grow.meter__arrow,
-.meter__progress--grow--big.meter__arrow {
+.game--started .meter__progress--grow.meter__arrow,
+.game--started .meter__progress--grow--big.meter__arrow {
   transition: opacity var(--stats-color-transition-duration) ease, color 0s;
   color: green;
   opacity: 1;
@@ -128,6 +128,7 @@ button {
 
 .meter {
   width: 15vw;
+  color: white;
 }
 
 .meter__label {
@@ -138,7 +139,6 @@ button {
 }
 .meter__name {
   white-space: nowrap;
-  color: #fff;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -324,4 +324,22 @@ button {
 /* this class is dynamically added by textFit */
 .textFitAlignVert {
   max-height: 100%;
+}
+
+.game--ended .red-glow {
+  --glow-color: red;
+  animation: glow 1.5s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes glow {
+  0% {
+    box-shadow: rgba(0, 0, 0, 0.56) 0px 0px 15px 2px;
+  }
+  50% {
+    box-shadow: var(--glow-color) 0px 0px 15px 2px;
+  }
+  100% {
+    box-shadow: rgba(0, 0, 0, 0.56) 0px 0px 15px 2px;
+  }
 }

--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -305,6 +305,8 @@ button {
   color: var(--color-error);
   margin-top: 2rem;
   height: calc(100% - 10rem);
+  margin-left: 4rem;
+  margin-right: 4rem;
 }
 
 .end__restart_button {

--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -291,20 +291,17 @@ button {
 }
 
 .end {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
   font-size: 6vw;
 
   width: 100%;
   color: #fff;
   text-align: center;
+  flex-grow: 1;
 }
 
 .end__message {
   color: var(--color-error);
+  margin-top: 2rem;
   margin-bottom: 2rem;
 }
 

--- a/elements/reigns/src/style.css
+++ b/elements/reigns/src/style.css
@@ -297,10 +297,19 @@ button {
   color: #fff;
   text-align: center;
   flex-grow: 1;
+  flex-shrink: 1;
+  overflow: hidden;
 }
 
 .end__message {
   color: var(--color-error);
+  margin-top: 2rem;
+  height: calc(100% - 10rem);
+}
+
+.end__restart_button {
+  display: block;
+  margin: auto;
   margin-top: 2rem;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
this PR 
 - adds an option deathMessage for each stats, overriding the default game death message
 - keep the stats visible on the death screen
 - refactor the main Game component to split the different screens