### PR TITLE
:bug: selected card should fill after countdown

### DIFF
--- a/elements/reigns/src/Game.tsx
+++ b/elements/reigns/src/Game.tsx
@@ -34,10 +34,18 @@ export const Game = () => {
   );
   const store = useStore<AppState>();
   const isHost = getIsHost({ currentHost });
-  const yesProgress = useSelector(
-    (state: AppState) => state.voting.yesProgress
+  const yesProgress = useSelector((state: AppState) =>
+    state.voting.answer === "Yes" &&
+    Countdown.from(state.voting.countdown).isLocked
+      ? 1
+      : state.voting.yesProgress
   );
-  const noProgress = useSelector((state: AppState) => state.voting.noProgress);
+  const noProgress = useSelector((state: AppState) =>
+    state.voting.answer === "No" &&
+    Countdown.from(state.voting.countdown).isLocked
+      ? 1
+      : state.voting.noProgress
+  );
   const yesVotesMissing = useSelector(
     (state: AppState) => state.voting.yesVotesMissing
   );


### PR DESCRIPTION
this PR fixes the fact that the card is not filled after a countdown is finish.
this is because the progress was never set to 1.
this PR override the progress props provided to the component when an answer is selected by countdown