### PR TITLE
Feature/fres 1522 single answer

### DIFF
--- a/elements/reigns/src/AnswerArea.tsx
+++ b/elements/reigns/src/AnswerArea.tsx
@@ -1,12 +1,20 @@
 import { mockSdkVote } from "./mockSdkVote";
 
-export const AnswerArea = ({ answer }: { answer: "yes" | "no" }) => {
+export const AnswerArea = ({
+  answer,
+  visible,
+}: {
+  answer: "yes" | "no";
+  visible: boolean;
+}) => {
   return (
     <div className="answer">
-      <div
-        className={`answer__zone answer--${answer}`}
-        onClick={() => mockSdkVote(answer)}
-      ></div>
+      {visible && (
+        <div
+          className={`answer__zone answer--${answer}`}
+          onClick={() => mockSdkVote(answer)}
+        ></div>
+      )}
     </div>
   );
 };

--- a/elements/reigns/src/AnswerText.tsx
+++ b/elements/reigns/src/AnswerText.tsx
@@ -10,7 +10,7 @@ const getVotesMissingMessage = (votesMissing: number) => {
   return `${votesMissing} votes ${VOTES_MISSING_SUFFIX}`;
 };
 
-type Props = {
+export type AnswerTextProps = {
   text: string;
   answer: "yes" | "no";
   progress: number;
@@ -24,7 +24,7 @@ export const AnswerText = ({
   progress,
   votesMissing,
   color,
-}: Props) => {
+}: AnswerTextProps) => {
   const isChangingQuestion = useSelector(
     (state: AppState) => state.transition.question
   );

--- a/elements/reigns/src/OptionalAnswerText.tsx
+++ b/elements/reigns/src/OptionalAnswerText.tsx
@@ -1,0 +1,12 @@
+import { AnswerTextProps, AnswerText } from "./AnswerText";
+
+export const OptionalAnswerText = ({
+  visible,
+  ...props
+}: { visible: boolean } & AnswerTextProps) => {
+  if (!visible) {
+    return <div className="answer"></div>;
+  }
+
+  return <AnswerText {...props} />;
+};

--- a/elements/reigns/src/features/game/validateGameDefinition.test.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.test.ts
@@ -151,7 +151,7 @@ describe("validateGameDefinition", () => {
       ).toThrow();
     });
 
-    it("should thrown if no answer_yes and no answer_no", () => {
+    it("should throw if no answer_yes and no answer_no", () => {
       const card = createDefaultCard();
       delete (card as any).answer_no;
       delete (card as any).answer_yes;

--- a/elements/reigns/src/features/game/validateGameDefinition.test.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.test.ts
@@ -159,14 +159,14 @@ describe("validateGameDefinition", () => {
       expect(() => validateCards([card])).toThrow();
     });
 
-    it("should not throw if with a valid answer_yes and no answer_no", () => {
+    it("should not throw when a valid answer_yes and no answer_no", () => {
       const card = createDefaultCard();
       delete (card as any).answer_no;
       (card as any).answer_yes = "yes";
       expect(() => validateCards([card])).not.toThrow();
     });
 
-    it("should not throw if with a valid answer_no and no answer_yes", () => {
+    it("should not throw when a valid answer_no and no answer_yes", () => {
       const card = createDefaultCard();
       delete (card as any).answer_yes;
       (card as any).answer_no = "no";

--- a/elements/reigns/src/features/game/validateGameDefinition.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.ts
@@ -88,6 +88,10 @@ export const validateCards = (cards: Card[] | undefined): Card[] => {
       }
     }
 
+    if (!card.answer_no && !card.answer_yes) {
+      throw new Error(`Card ${i + 1} is invalid. At least an answer mut be supplied`)
+    }
+
     validateFlags(getFlags(card, "yes_custom"), "yes_custom", i + 1);
     validateFlags(getFlags(card, "no_custom"), "no_custom", i + 1);
 

--- a/elements/reigns/src/features/game/validateGameDefinition.ts
+++ b/elements/reigns/src/features/game/validateGameDefinition.ts
@@ -89,7 +89,7 @@ export const validateCards = (cards: Card[] | undefined): Card[] => {
     }
 
     if (!card.answer_no && !card.answer_yes) {
-      throw new Error(`Card ${i + 1} is invalid. At least an answer mut be supplied`)
+      throw new Error(`Card ${i + 1} is invalid. At least one answer must be supplied`)
     }
 
     validateFlags(getFlags(card, "yes_custom"), "yes_custom", i + 1);

--- a/elements/reigns/src/features/voting/useVoteListener.test.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.test.ts
@@ -1,0 +1,141 @@
+import { renderHook } from "@testing-library/react";
+import { GamePhase } from "../../constants";
+import { mockSdk } from "../../mocks";
+import { useVoteListener } from "./useVoteListener";
+import { Game } from "../game/Game";
+import { PersistedGameState, Card } from "../game/types";
+
+describe("use vote listener", () => {
+  const subscribeToGlobalEvent = jest.fn().mockReturnValue(jest.fn());
+  const triggerEvent = jest.fn();
+  beforeEach(() => {
+    mockSdk({ subscribeToGlobalEvent, triggerEvent });
+    jest.clearAllMocks();
+  });
+  describe("when phase is started", () => {
+    it("subscribes to custom.reign.yes", () => {
+      renderHook(() => useVoteListener(GamePhase.STARTED));
+
+      expect(subscribeToGlobalEvent).toHaveBeenCalledWith(
+        "custom.reign.yes",
+        expect.any(Function)
+      );
+    });
+    it("subscribes to custom.reign.no", () => {
+      renderHook(() => useVoteListener(GamePhase.STARTED));
+
+      expect(subscribeToGlobalEvent).toHaveBeenCalledWith(
+        "custom.reign.no",
+        expect.any(Function)
+      );
+    });
+    it("subscribes to custom.reign.remove-vote", () => {
+      renderHook(() => useVoteListener(GamePhase.STARTED));
+
+      expect(subscribeToGlobalEvent).toHaveBeenCalledWith(
+        "custom.reign.remove-vote",
+        expect.any(Function)
+      );
+    });
+
+    describe("when receiving custom.reign.yes", () => {
+      describe("when current card has an answer_yes value", () => {
+        it("triggers custom.reign.local_yes event", () => {
+          jest.spyOn(Game.prototype, "retrieve").mockImplementation(
+            () =>
+              ({
+                selectedCard: {
+                  card: "card",
+                  answer_yes: "yes !",
+                } as Card,
+              } as PersistedGameState)
+          );
+
+          renderHook(() => useVoteListener(GamePhase.STARTED));
+          const listener = subscribeToGlobalEvent.mock.calls.find(
+            (call) => call[0] === "custom.reign.yes"
+          )[1];
+          listener();
+
+          expect(triggerEvent).toBeCalledWith({
+            eventName: "custom.reign.local_yes",
+          });
+        });
+      });
+
+      describe("when current card has no answer_yes value", () => {
+        it("does triggers custom.reign.local_yes event", () => {
+          jest.spyOn(Game.prototype, "retrieve").mockImplementation(
+            () =>
+              ({
+                selectedCard: {
+                  card: "card",
+                } as Card,
+              } as PersistedGameState)
+          );
+          renderHook(() => useVoteListener(GamePhase.STARTED));
+          const listener = subscribeToGlobalEvent.mock.calls.find(
+            (call) => call[0] === "custom.reign.yes"
+          )[1];
+          listener();
+
+          expect(triggerEvent).not.toBeCalledWith("custom.reign.local_yes");
+        });
+      });
+    });
+
+    describe("when receiving custom.reign.no", () => {
+      describe("when current card has an answer_no value", () => {
+        it("triggers custom.reign.no event", () => {
+          jest.spyOn(Game.prototype, "retrieve").mockImplementation(
+            () =>
+              ({
+                selectedCard: {
+                  card: "card",
+                  answer_no: "no !",
+                } as Card,
+              } as PersistedGameState)
+          );
+
+          renderHook(() => useVoteListener(GamePhase.STARTED));
+          const listener = subscribeToGlobalEvent.mock.calls.find(
+            (call) => call[0] === "custom.reign.no"
+          )[1];
+          listener();
+
+          expect(triggerEvent).toBeCalledWith({
+            eventName: "custom.reign.local_no",
+          });
+        });
+      });
+
+      describe("when current card has no answer_no value", () => {
+        it("does triggers custom.reign.local_no event", () => {
+          jest.spyOn(Game.prototype, "retrieve").mockImplementation(
+            () =>
+              ({
+                selectedCard: {
+                  card: "card",
+                } as Card,
+              } as PersistedGameState)
+          );
+          renderHook(() => useVoteListener(GamePhase.STARTED));
+          const listener = subscribeToGlobalEvent.mock.calls.find(
+            (call) => call[0] === "custom.reign.no"
+          )[1];
+          listener();
+
+          expect(triggerEvent).not.toBeCalledWith("custom.reign.local_no");
+        });
+      });
+    });
+  });
+
+  describe("when phase is NOT_STARTED", () => {
+    it("does not subscribe to event", () => {
+      renderHook(() => useVoteListener(GamePhase.NOT_STARTED));
+
+      expect(subscribeToGlobalEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/elements/reigns/src/features/voting/useVoteListener.test.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.test.ts
@@ -64,7 +64,7 @@ describe("use vote listener", () => {
       });
 
       describe("when current card has no answer_yes value", () => {
-        it("does triggers custom.reign.local_yes event", () => {
+        it("does not trigger custom.reign.local_yes event", () => {
           jest.spyOn(Game.prototype, "retrieve").mockImplementation(
             () =>
               ({
@@ -110,7 +110,7 @@ describe("use vote listener", () => {
       });
 
       describe("when current card has no answer_no value", () => {
-        it("does triggers custom.reign.local_no event", () => {
+        it("does not trigger custom.reign.local_no event", () => {
           jest.spyOn(Game.prototype, "retrieve").mockImplementation(
             () =>
               ({

--- a/elements/reigns/src/features/voting/useVoteListener.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { GamePhase } from "../../constants";
 import { Logger } from "../../Logger";
 import { getSdk } from "../../sdk";
+import { Game } from "../game/Game";
 import { persistParticipantVote } from "./persistence";
 
 export const useVoteListener = (phase: GamePhase) => {
@@ -9,13 +10,20 @@ export const useVoteListener = (phase: GamePhase) => {
     if (phase === GamePhase.STARTED) {
       const sdk = getSdk();
       const yesListener = sdk.subscribeToGlobalEvent("custom.reign.yes", () => {
-        Logger.log(Logger.VOTE, "vote yes");
-        persistParticipantVote(sdk.localParticipant.id, "Yes");
+        debugger;
+        if (new Game().retrieve().selectedCard?.answer_yes) {
+          Logger.log(Logger.VOTE, "vote yes");
+          persistParticipantVote(sdk.localParticipant.id, "Yes");
+          sdk.triggerEvent({ eventName: "custom.reign.local_yes" });
+        }
       });
 
       const noListener = sdk.subscribeToGlobalEvent("custom.reign.no", () => {
-        Logger.log(Logger.VOTE, "vote no");
-        persistParticipantVote(sdk.localParticipant.id, "No");
+        if (new Game().retrieve().selectedCard?.answer_no) {
+          Logger.log(Logger.VOTE, "vote no");
+          persistParticipantVote(sdk.localParticipant.id, "No");
+          sdk.triggerEvent({ eventName: "custom.reign.local_no" });
+        }
       });
 
       const removeVoteListener = sdk.subscribeToGlobalEvent(

--- a/elements/reigns/src/features/voting/useVoteListener.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.ts
@@ -10,7 +10,6 @@ export const useVoteListener = (phase: GamePhase) => {
     if (phase === GamePhase.STARTED) {
       const sdk = getSdk();
       const yesListener = sdk.subscribeToGlobalEvent("custom.reign.yes", () => {
-        debugger;
         if (new Game().retrieve().selectedCard?.answer_yes) {
           Logger.log(Logger.VOTE, "vote yes");
           persistParticipantVote(sdk.localParticipant.id, "Yes");

--- a/elements/reigns/src/features/voting/useVoteListener.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.ts
@@ -10,6 +10,7 @@ export const useVoteListener = (phase: GamePhase) => {
     if (phase === GamePhase.STARTED) {
       const sdk = getSdk();
       const yesListener = sdk.subscribeToGlobalEvent("custom.reign.yes", () => {
+        console.log("maxired yes listener", new Game().retrieve().selectedCard);
         if (new Game().retrieve().selectedCard?.answer_yes) {
           Logger.log(Logger.VOTE, "vote yes");
           persistParticipantVote(sdk.localParticipant.id, "Yes");

--- a/elements/reigns/src/features/voting/useVoteListener.ts
+++ b/elements/reigns/src/features/voting/useVoteListener.ts
@@ -10,7 +10,6 @@ export const useVoteListener = (phase: GamePhase) => {
     if (phase === GamePhase.STARTED) {
       const sdk = getSdk();
       const yesListener = sdk.subscribeToGlobalEvent("custom.reign.yes", () => {
-        console.log("maxired yes listener", new Game().retrieve().selectedCard);
         if (new Game().retrieve().selectedCard?.answer_yes) {
           Logger.log(Logger.VOTE, "vote yes");
           persistParticipantVote(sdk.localParticipant.id, "Yes");

--- a/elements/reigns/src/screens/StartedScreen.tsx
+++ b/elements/reigns/src/screens/StartedScreen.tsx
@@ -33,34 +33,39 @@ export const StartedScreen = ({
     <div className="screen game--started" onClick={doRestartGame}>
       <Header definition={gameDefinition} stats={currentStats} />
       <Question card={selectedCard} />
-      <div className='answers'>
-        <AnswerText
-          text={selectedCard.answer_no || "No"}
-          answer="no"
-          progress={noProgress}
-          color="#e200a4"
-          votesMissing={noVotesMissing}
-        />
-        <div className='answer'>
+      <div className="answers">
+        {selectedCard.answer_no ? (
+          <AnswerText
+            text={selectedCard.answer_no || "No"}
+            answer="no"
+            progress={noProgress}
+            color="#e200a4"
+            votesMissing={noVotesMissing}
+          />
+        ) : (
+          <div className="answer" />
+        )}
+        <div className="answer">
           <div className="round">
             {gameDefinition.roundName} {round}
           </div>
         </div>
 
-        <AnswerText
-        text={selectedCard.answer_yes || "Yes"}
-        answer="yes"
-        progress={yesProgress}
-        color="#9e32d6"
-        votesMissing={yesVotesMissing}
-      />
-
+        {selectedCard.answer_yes ? (
+          <AnswerText
+            text={selectedCard.answer_yes || "Yes"}
+            answer="yes"
+            progress={yesProgress}
+            color="#9e32d6"
+            votesMissing={yesVotesMissing}
+          />
+        ) : (
+          <div className="answer" />
+        )}
       </div>
     </div>
     <div className="answers floor">
-      <AnswerArea
-        answer="no"
-      />
+      <AnswerArea answer="no" visible={Boolean(selectedCard.answer_no)} />
       <div className="answer answer--neutral">
         {countdown.isVoting && (
           <div className="countdown" data-testid="countdown">
@@ -68,7 +73,7 @@ export const StartedScreen = ({
           </div>
         )}
       </div>
-      <AnswerArea answer="yes" />
+      <AnswerArea answer="yes" visible={Boolean(selectedCard.answer_yes)} />
     </div>
   </>
 );

--- a/elements/reigns/src/screens/StartedScreen.tsx
+++ b/elements/reigns/src/screens/StartedScreen.tsx
@@ -4,7 +4,7 @@ import { Question } from "../Question";
 import { AnswerArea } from "../AnswerArea";
 import { Countdown } from "../Countdown";
 import { Card, GameDefinition } from "../features/game/types";
-import { AnswerText } from "../AnswerText";
+import { OptionalAnswerText } from "../OptionalAnswerText";
 
 export const StartedScreen = ({
   gameDefinition,
@@ -34,34 +34,28 @@ export const StartedScreen = ({
       <Header definition={gameDefinition} stats={currentStats} />
       <Question card={selectedCard} />
       <div className="answers">
-        {selectedCard.answer_no ? (
-          <AnswerText
-            text={selectedCard.answer_no || "No"}
-            answer="no"
-            progress={noProgress}
-            color="#e200a4"
-            votesMissing={noVotesMissing}
-          />
-        ) : (
-          <div className="answer" />
-        )}
+        <OptionalAnswerText
+          visible={Boolean(selectedCard.answer_no)}
+          text={selectedCard.answer_no || "No"}
+          answer="no"
+          progress={noProgress}
+          color="#e200a4"
+          votesMissing={noVotesMissing}
+        />
+
         <div className="answer">
           <div className="round">
             {gameDefinition.roundName} {round}
           </div>
         </div>
-
-        {selectedCard.answer_yes ? (
-          <AnswerText
-            text={selectedCard.answer_yes || "Yes"}
-            answer="yes"
-            progress={yesProgress}
-            color="#9e32d6"
-            votesMissing={yesVotesMissing}
-          />
-        ) : (
-          <div className="answer" />
-        )}
+        <OptionalAnswerText
+          visible={Boolean(selectedCard.answer_yes)}
+          text={selectedCard.answer_yes || "Yes"}
+          answer="yes"
+          progress={yesProgress}
+          color="#9e32d6"
+          votesMissing={yesVotesMissing}
+        />
       </div>
     </div>
     <div className="answers floor">

--- a/inventory/index.json
+++ b/inventory/index.json
@@ -348,7 +348,7 @@
             "rotation": 0
           },
           "appearance": {
-            "EVENTS": "[{\"event\":\"avatar.stopped.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"mezljzbhbdowtosc2lxop\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.no' })\"}},{\"id\":\"yypjpec65doggdgthibpk\",\"type\":\"SET_PARTICIPANT_COLOR\",\"payload\":{\"color\":\"#e200a4\"}}]},{\"event\":\"avatar.left.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"dffpqjjhi1h4yvv1k2cqe\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.remove-vote' })\"}},{\"id\":\"mgezsn-lyzivq6uholety\",\"type\":\"RESET_PARTICIPANT_COLOR\",\"payload\":{}}]}]",
+            "EVENTS": "[{\"event\":\"avatar.stopped.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"mezljzbhbdowtosc2lxop\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.no' })\"}}]},{\"event\":\"avatar.left.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"dffpqjjhi1h4yvv1k2cqe\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.remove-vote' })\"}},{\"id\":\"mgezsn-lyzivq6uholety\",\"type\":\"RESET_PARTICIPANT_COLOR\",\"payload\":{}}]},{\"event\":\"custom.reign.local_no\",\"scope\":\"global\",\"actions\":[{\"id\":\"yypjpec65doggdgthibpk\",\"type\":\"SET_PARTICIPANT_COLOR\",\"payload\":{\"color\":\"#e200a4\"}}]}]",
             "COLOR": "#5905F8",
             "STROKE_COLOR": 13224393,
             "STROKE_THICKNESS": 0,
@@ -370,7 +370,7 @@
             "rotation": 0
           },
           "appearance": {
-            "EVENTS": "[{\"event\":\"avatar.stopped.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"v8k_3akjfshcvjw6xfcrp\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.yes' })\"}},{\"id\":\"y3i0iut57-szpwrxdzloq\",\"type\":\"SET_PARTICIPANT_COLOR\",\"payload\":{\"color\":\"#9e32d6\"}}]},{\"event\":\"avatar.left.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"ef0krxipjig7ap4u8xl4s\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.remove-vote' })\"}},{\"id\":\"_h4x84tmsd2px2wjtqoxo\",\"type\":\"RESET_PARTICIPANT_COLOR\",\"payload\":{}}]}]",
+            "EVENTS": "[{\"event\":\"avatar.stopped.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"v8k_3akjfshcvjw6xfcrp\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.yes' })\"}}]},{\"event\":\"avatar.left.zone\",\"scope\":\"self\",\"actions\":[{\"id\":\"ef0krxipjig7ap4u8xl4s\",\"type\":\"SCRIPT\",\"payload\":{\"script\":\"fresco.triggerEvent({ eventName: 'custom.reign.remove-vote' })\"}},{\"id\":\"_h4x84tmsd2px2wjtqoxo\",\"type\":\"RESET_PARTICIPANT_COLOR\",\"payload\":{}}]},{\"event\":\"custom.reign.local_yes\",\"scope\":\"global\",\"actions\":[{\"id\":\"y3i0iut57-szpwrxdzloq\",\"type\":\"SET_PARTICIPANT_COLOR\",\"payload\":{\"color\":\"#9e32d6\"}}]}]",
             "COLOR": "#5905F8",
             "STROKE_COLOR": 13224393,
             "STROKE_THICKNESS": 0,


### PR DESCRIPTION
Hi,

this PR implements the fact that a question can have a single answer.
If so, it does not show the answer zone.

For spaces created with the inventory item, using game definition with this new feature requires the space the be edited.

<img width="1793" alt="Screenshot 2022-08-18 at 17 55 45" src="https://user-images.githubusercontent.com/1194083/185440224-9a462678-7a20-4669-86a9-43008dd6e78b.png">


can be tested with the following card:

```csv
card,weight,answer_yes,answer_no
Are you ready ?, 100,YES!,
Do you want to stop ?, 100,,NO!
```
