### PR TITLE
:liptisck: hidden start button while editing

### DIFF
--- a/elements/timer/index.css
+++ b/elements/timer/index.css
@@ -244,3 +244,7 @@ input:hover:not(:disabled) {
     display: block;
   }
 }
+
+.inputs-group:has(input:focus) + .buttons-group .button--start {
+  visibility: hidden;
+}

--- a/elements/timer/index.js
+++ b/elements/timer/index.js
@@ -45,7 +45,7 @@ function render(timer) {
 
   main.innerHTML = `
       <div>
-      <form id="form" onchange="valueForm(event)" onkeyup="valueForm(event)">
+      <form id="form" onchange="valueForm(event)" >
         <div class="inputs-group">
         <input ${renderIf(
           fresco.element.state.timer !== "initial" || !admin,


### PR DESCRIPTION
This Pr fix an issue with the timer, when integrated inside a fresco space.

When the duration is edited, we update the element at every change, which retriggers the rendering of the whole component.
that PR changes that.

I also hide the start button when editing a field, because of a similar bug: when clicking on the button while editing a field, we do trigger the onChange handler, and then not the start, requiring a double click on the start button.

If we have more bugs or plan to create new feature inside this timer, it might be useful to consider switching to (p)react
