### PR TITLE
:wrench: base config for hosting

### DIFF
--- a/elements/kahoot-controller/vite.config.ts
+++ b/elements/kahoot-controller/vite.config.ts
@@ -5,4 +5,5 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), basicSsl()],
+  base: "",
 });


### PR DESCRIPTION
Currently, loading Kahoot! controller extension with `extension://fres-co.github.io/fresco-community/elements/kahoot-controller/dist/` does not work because it tries to load assets from the same folder.

this PR copy the config from Reign folder to load config from the same base directory as index.html file