### PR TITLE
:bug: kahoot sdk not ready

### DIFF
--- a/elements/kahoot-controller/src/App.tsx
+++ b/elements/kahoot-controller/src/App.tsx
@@ -87,12 +87,13 @@ const useAppStore = () => {
     if (!loadedRef.current) {
       loadedRef.current = true;
 
-      fresco.onStateChanged(() => {
-        dispatch({
-          type: ACTIONS.FRESCO_STATE_CHANGED,
-        });
-      });
       fresco.onReady(() => {
+        fresco.onStateChanged(() => {
+          dispatch({
+            type: ACTIONS.FRESCO_STATE_CHANGED,
+          });
+        });
+
         dispatch({
           type: ACTIONS.FRESCO_READY,
         });


### PR DESCRIPTION
this Pr solves the fact that the Kahoot! controller extension is not waiting for the fresco SDK to be ready before calling onStateChanged