### PR TITLE
:rotating_light: try to fix ci by forcing node version

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-        node-version: 16
+          node-version: 16
       ## START PREPARE ANSWER-BOARD ##
       - name: Install answer-board dependencies
         working-directory: ./elements/answer-board

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+      - uses: actions/setup-node@v3
+        with:
+        node-version: 16
       ## START PREPARE ANSWER-BOARD ##
       - name: Install answer-board dependencies
         working-directory: ./elements/answer-board
@@ -30,21 +32,21 @@ jobs:
       ## END PREPARE ANSWER-BOARD ##
 
       ## START PREPARE REIGNS ##
-      # - name: Install reigns dependencies
-      #   working-directory: ./elements/reigns
-      #   run: npm i
+      - name: Install reigns dependencies
+        working-directory: ./elements/reigns
+        run: npm i
 
-      # - name: Test reigns
-      #   working-directory: ./elements/reigns
-      #   run: npm run test
+      - name: Test reigns
+        working-directory: ./elements/reigns
+        run: npm run test
 
-      # - name: Build reigns
-      #   working-directory: ./elements/reigns
-      #   run: npm run build
+      - name: Build reigns
+        working-directory: ./elements/reigns
+        run: npm run build
 
-      # - name: Clean-up reigns
-      #   working-directory: ./elements/reigns
-      #   run: rm -rf node_modules && rm index.html
+      - name: Clean-up reigns
+        working-directory: ./elements/reigns
+        run: rm -rf node_modules && rm index.html
       ## END PREPARE REIGNS ##
 
       ## START PREPARE KAHOOT CONTROLLER##

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install reigns dependencies
         working-directory: ./elements/reigns
         run: npm i


### PR DESCRIPTION
Hi,

this PR try to fix the Reigns build, by force node to version 16.
I noticed it was broken when using node 18