### PR TITLE
:lipstick: automatic empty title color computation

### DIFF
--- a/elements/answer-board/src/App.jsx
+++ b/elements/answer-board/src/App.jsx
@@ -12,6 +12,32 @@ const initialState = {
   textColor: "#000",
 };
 
+/**
+ * Calculate brightness value by RGB or HEX color.
+ * @param color (String) The color value in RGB or HEX (for example: #000000 || #000 || rgb(0,0,0) || rgba(0,0,0,0))
+ * @returns (Number) The brightness value (dark) 0 ... 255 (light)
+ */
+function brightnessByColor(color) {
+  var color = "" + color,
+    isHEX = color.indexOf("#") == 0,
+    isRGB = color.indexOf("rgb") == 0;
+  if (isHEX) {
+    var m = color.substr(1).match(color.length == 7 ? /(\S{2})/g : /(\S{1})/g);
+    if (m)
+      var r = parseInt(m[0], 16),
+        g = parseInt(m[1], 16),
+        b = parseInt(m[2], 16);
+  }
+  if (isRGB) {
+    var m = color.match(/(\d+){3}/g);
+    if (m)
+      var r = m[0],
+        g = m[1],
+        b = m[2];
+  }
+  if (typeof r != "undefined") return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
 const hash = function (str, seed = 0) {
   let h1 = 0xdeadbeef ^ seed,
     h2 = 0x41c6ce57 ^ seed;
@@ -111,6 +137,17 @@ const Home = () => {
 
   const allowedAnswers = fresco.element.state.maxAnswersPerParticipant;
   const backgroundColor = fresco.element.state.backgroundColor;
+  const backgroundbrightness = brightnessByColor(
+    fresco.element.state.backgroundColor
+  );
+
+  const color =
+    backgroundbrightness > 200
+      ? "#999"
+      : backgroundbrightness > 127
+      ? "#222222"
+      : "#eeeeee";
+
   const borderRadius = fresco.element.state.borderRadius;
   const titleColor = fresco.element.state.titleColor;
 
@@ -170,7 +207,9 @@ const Home = () => {
           ))}
         </ul>
       ) : (
-        <p className="explanation">No answers yet, add your own!</p>
+        <p className="explanation" style={{ color }}>
+          No answers yet, add your own!
+        </p>
       )}
 
       <form>


### PR DESCRIPTION
Hi,


I recently noticed that depending of the background color, the empty text might be unreadable.

this PR improves it by automatically switching the text color based on the background color.


https://user-images.githubusercontent.com/1194083/221656214-d4f356f7-3057-4887-9c1d-0ea67c3d45cd.mov


