### PR TITLE
:liptsick: no background leaking of phone container

### DIFF
--- a/elements/kahoot-controller/src/index.css
+++ b/elements/kahoot-controller/src/index.css
@@ -6,7 +6,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #371271;
+  background-color: transparent;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
this PR removes the default color of the kahoot controller background, so it can match any background.
The color was originally set before the phone container