### PR TITLE
:sparkles: add a new qrcode element

### DIFF
--- a/elements/qrcode/README.md
+++ b/elements/qrcode/README.md
@@ -1,0 +1,31 @@
+# description
+
+This Element enables the display of an qr code
+
+The text/url to be encoded can be provided as a parameter in the fresco element.
+
+# Set up
+
+1. Add an entry in hosts:
+
+```
+    127.0.0.1 dev-community.fres.co
+```
+
+2. Set up your web server to respond to https://dev-community.fres.co/ (points to the root of the repo)
+
+# To add the qrcode to a fres.co space
+
+1. Copy the following snippet
+
+```
+    extension://dev-community.fres.co/elements/qrcode/index.htm
+```
+
+2. Paste it in the space
+
+# Source of inspiration
+
+Although we have already deviated from Miro's SDK, it is a good reference.
+https://developers.miro.com/docs/how-to-start
+https://github.com/miroapp/app-examples/blob/master/miro.d.ts

--- a/elements/qrcode/index.htm
+++ b/elements/qrcode/index.htm
@@ -11,15 +11,13 @@
         margin: 0;
         user-select: none;
         overflow: hidden;
+        background-color: #fff;
       }
 
       #canvas {
         width: 100%;
         height: 100%;
-        color: var(--color, #fff);
       }
-
-      
     </style>
   </head>
 

--- a/elements/qrcode/index.htm
+++ b/elements/qrcode/index.htm
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode/1.5.1/qrcode.min.js"></script>
+    <script src="../../loadSdk.js"></script>
+    <style>
+      body {
+        display: flex;
+        font-family: Arial, Helvetica, sans-serif;
+        font-weight: bold;
+        padding: 0;
+        margin: 0;
+        user-select: none;
+        overflow: hidden;
+      }
+
+      #canvas {
+        width: 100%;
+        height: 100%;
+        color: var(--color, #fff);
+      }
+
+      
+    </style>
+  </head>
+
+  <body>
+    <canvas id="canvas"></canvas>
+    <script src="./index.js"></script>
+  </body>
+</html>

--- a/elements/qrcode/index.js
+++ b/elements/qrcode/index.js
@@ -16,7 +16,7 @@ fresco.onReady(function () {
   };
 
   fresco.initialize(defaultState, {
-    title: "Qrcoe",
+    title: "QRcode",
     toolbarButtons: [
       {
         title: "text or url to show",

--- a/elements/qrcode/index.js
+++ b/elements/qrcode/index.js
@@ -2,21 +2,23 @@ const canvas = document.getElementById("canvas");
 
 function showCard(state) {
   QRCode.toCanvas(canvas, state.text, { width: Math.min(window.innerWidth, window.innerHeight) }, function (error) {
-    if (error) console.error(error)
-  })
+    if (error) {
+      console.error(error);
+    }
+  });
 }
 
 fresco.onReady(function () {
   fresco.onStateChanged(function () {
-    showCard(fresco.element.state)
+    showCard(fresco.element.state);
   });
 
   const defaultState = {
-    text: 'https://github.com/fres-co/fresco-community/tree/master/elements/qrcode',
+    text: 'https://www.fres.co',
   };
 
   fresco.initialize(defaultState, {
-    title: "QRcode",
+    title: "QR code",
     toolbarButtons: [
       {
         title: "text or url to show",
@@ -29,5 +31,5 @@ fresco.onReady(function () {
 
 
 window.addEventListener('resize', () => {
-  showCard(fresco.element.state)
-})
+  showCard(fresco.element.state);
+});

--- a/elements/qrcode/index.js
+++ b/elements/qrcode/index.js
@@ -1,0 +1,33 @@
+const canvas = document.getElementById("canvas");
+
+function showCard(state) {
+  QRCode.toCanvas(canvas, state.text, { width: Math.min(window.innerWidth, window.innerHeight) }, function (error) {
+    if (error) console.error(error)
+  })
+}
+
+fresco.onReady(function () {
+  fresco.onStateChanged(function () {
+    showCard(fresco.element.state)
+  });
+
+  const defaultState = {
+    text: 'https://github.com/fres-co/fresco-community/tree/master/elements/qrcode',
+  };
+
+  fresco.initialize(defaultState, {
+    title: "Qrcoe",
+    toolbarButtons: [
+      {
+        title: "text or url to show",
+        ui: { type: "string" },
+        property: "text",
+      },
+    ],
+  });
+});
+
+
+window.addEventListener('resize', () => {
+  showCard(fresco.element.state)
+})


### PR DESCRIPTION
This PR adds a new elements that can be used to display a text/url encoded as qrcode.

it can be added int he space using extension://dev-community.fres.co/elements/qrcode/index.htm 

it uses https://github.com/soldair/node-qrcode with default options to create the code