### PR TITLE
:bug: fix public carousel use in inventory

### DIFF
--- a/inventory/index.json
+++ b/inventory/index.json
@@ -688,7 +688,7 @@
             "VISIBLE_IN_CONTAINER": true,
             "PINNED": false,
             "EVENTS": "",
-            "SOURCE": "https://dev-community.fres.co/elements/carousel/index.htm"
+            "SOURCE": "https://fres-co.github.io/fresco-community/elements/carousel/index.htm"
           }
         }
       ],
@@ -731,7 +731,7 @@
             "VISIBLE_IN_CONTAINER": true,
             "PINNED": false,
             "EVENTS": "",
-            "SOURCE": "https://dev-community.fres.co/elements/carousel/index.htm"
+            "SOURCE": "https://fres-co.github.io/fresco-community/elements/carousel/index.htm"
           }
         }
       ],


### PR DESCRIPTION
this PR fixes the fact that dev URL is currently provided as source of element for carousel.
